### PR TITLE
gen-bundle-image: Add bundle as label to have bundle file as value

### DIFF
--- a/gen-bundle-image.sh
+++ b/gen-bundle-image.sh
@@ -23,23 +23,23 @@ function generate_image {
    local preset=$1
 
    if [[ ${preset} = "podman" ]]; then
-       cat <<EOF | podman build --os darwin --arch arm64 --tag podman-bundle:darwin-arm64 -f - .
+       cat <<EOF | podman build --label bundle=${vfkit_bundle_arm64} --os darwin --arch arm64 --tag podman-bundle:darwin-arm64 -f - .
 FROM scratch
 COPY ${vfkit_bundle_arm64} ${vfkit_bundle_arm64}.sig /
 EOF
    fi
 
-   cat <<EOF | podman build --os darwin --arch amd64 --tag ${preset}-bundle:darwin-amd64 -f - .
+   cat <<EOF | podman build --label bundle=${vfkit_bundle} --os darwin --arch amd64 --tag ${preset}-bundle:darwin-amd64 -f - .
 FROM scratch
 COPY ${vfkit_bundle} ${vfkit_bundle}.sig /
 EOF
 
-   cat <<EOF | podman build --os windows --arch amd64 --tag ${preset}-bundle:windows-amd64 -f - .
+   cat <<EOF | podman build --label bundle=${hyperv_bundle} --os windows --arch amd64 --tag ${preset}-bundle:windows-amd64 -f - .
 FROM scratch
 COPY ${hyperv_bundle} ${hyperv_bundle}.sig /
 EOF
 
-   cat <<EOF | podman build --os linux --arch amd64 --tag ${preset}-bundle:linux-amd64 -f - .
+   cat <<EOF | podman build  --label bundle=${libvirt_bundle} --os linux --arch amd64 --tag ${preset}-bundle:linux-amd64 -f - .
 FROM scratch
 COPY ${libvirt_bundle} ${libvirt_bundle}.sig /
 EOF


### PR DESCRIPTION
After building the image using this lable we can identify which
bundle ship with container image without extracting it.

```
$ skopeo inspect --authfile /home/prkumar/pull-secret --no-tags docker://quay.io/praveenkumar/podman-bundle:4.1.1
{
    "Name": "quay.io/praveenkumar/podman-bundle",
    "Digest": "sha256:0e9ba567738f1639fcaf7c368532dea59933e2bfd5c8db4f2d9540c371c1f9b2",
    "RepoTags": [],
    "Created": "2022-08-18T11:50:10.628039178Z",
    "DockerVersion": "",
    "Labels": {
        "bundle": "crc_podman_libvirt_4.1.1_amd64.crcbundle",
        "io.buildah.version": "1.26.2"
    },
    "Architecture": "amd64",
    "Os": "linux",
    "Layers": [
        "sha256:554b666c655e35321b370defa4448ac66507655a5eeb7b321d6b2faefd890fb8"
    ],
    "Env": [
        "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
    ]
}
```