### PR TITLE
build-patched-kao-kcmo-images: Add maxsize for merge commit

### DIFF
--- a/build-patched-kao-kcmo-images.sh
+++ b/build-patched-kao-kcmo-images.sh
@@ -75,7 +75,7 @@ function patch_and_push_image() {
     # Just fetch the upstream/rhaos-4.11-rhel-8 instead of all the branches and tags from upstream
     git fetch upstream rhaos-4.11-rhel-8 --no-tags
     git checkout --track origin/rhaos-4.11-rhel-8
-    git merge --no-edit ${vcs_ref}
+    git merge --no-ff -m "Merge commit ${vcs_ref} into rhaos-4.11-rhel-8" -m "MaxFileSize: 104857600" ${vcs_ref}
     git push origin HEAD
     rhpkg container-build  --target crc-1-rhel-8-candidate
     popd


### PR DESCRIPTION
This would fix following error and `AOS Automation Release Team` have it also for each commit downstream.
```
remote: Adding big files into git is bad. Once they are committed, they can not be removed and will have to be downloaded with each new clone.
remote: Please use "rhpkg upload" to put the files into lookaside cache and "rhpkg sources" to download them again.
remote: If you are absolutely sure you want to commit it, you can override the limit in your commit message by adding the following line. The size is in bytes.
remote:     - MaxFileSize: 123456
remote: Alternatively contact EXD SP to adjust the limit for this repository via
remote:   https://hurl.corp.redhat.com/sp-ticket
To ssh://pkgs.devel.redhat.com/containers/crc-cluster-kube-apiserver-operator
 ! [remote rejected]   HEAD -> rhaos-4.11-rhel-8 (pre-receive hook declined)
```