### PR TITLE
Remove downstream image for hostpath-csi-driver

### DIFF
--- a/kubevirt-hostpath-provisioner-csi/csi-driver/kustomization.yaml
+++ b/kubevirt-hostpath-provisioner-csi/csi-driver/kustomization.yaml
@@ -2,7 +2,7 @@ resources:
   - csi-kubevirt-hostpath-provisioner.yaml
 images:
   - name: quay.io/kubevirt/hostpath-csi-driver
-    newName: registry.redhat.io/container-native-virtualization/hostpath-csi-driver-rhel8
+    newName: quay.io/crcont/hostpath-csi-driver
     newTag: v4.11.0
   - name: k8s.gcr.io/sig-storage/csi-node-driver-registrar
     newName: registry.redhat.io/openshift4/ose-csi-node-driver-registrar


### PR DESCRIPTION
Downsteam image for hostpath-csi-driver does have image for arm64. we will revert back once it is available downstream.