### PR TITLE
Set fsGroupPolicy to File for hostpath-provisioner CSIDriver

### DIFF
--- a/kubevirt-hostpath-provisioner-csi/csi-driver-hostpath-provisioner.yaml
+++ b/kubevirt-hostpath-provisioner-csi/csi-driver-hostpath-provisioner.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   attachRequired: false
   storageCapacity: false
-  fsGroupPolicy: "None"
+  fsGroupPolicy: File
   # Supports persistent volumes.
   volumeLifecycleModes:
   - Persistent


### PR DESCRIPTION
File is the correct policy to use in our case, which allows the volumes file permissions to match the requested permissions from the pod

CSIDriver docs: https://kubernetes-csi.github.io/docs/csi-driver-object.html

this fixes the following permission denied error in the image registry pod when trying to mirror images

```
level=error msg="response completed with error" err.code=unknown err.detail="filesystem: mkdir /registry/docker: permission denied"
```