### PR TITLE
Add arch info to image tag

### DIFF
--- a/snc-library.sh
+++ b/snc-library.sh
@@ -37,9 +37,9 @@ function create_new_release_with_patched_images() {
     ${OC} adm release new -a ${OPENSHIFT_PULL_SECRET_PATH} --from-release=${OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE} \
 	    cluster-kube-apiserver-operator=${upstream_registry}/openshift-crc-cluster-kube-apiserver-operator@${kao_image_digest} \
 	    cluster-kube-controller-manager-operator=${upstream_registry}/openshift-crc-cluster-kube-controller-manager-operator@${kcmo_image_digest} \
-	    --to-image=quay.io/crcont/ocp-release:${openshift_version}
+	    --to-image=quay.io/crcont/ocp-release:${openshift_version}-${yq_ARCH}
     # Replace the release image override with crcont image
-    OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE=quay.io/crcont/ocp-release:${openshift_version}
+    OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE=quay.io/crcont/ocp-release:${openshift_version}-${yq_ARCH}
 }
 
 function run_preflight_checks() {


### PR DESCRIPTION
This patch is useful to run the arm64 and amd64, bundle creation job in parallel otherwise one job update the image and second job fails to run in between.

```
level=error msg=The bootstrap machine failed to download the release image
level=info msg=Pulling quay.io/crcont/ocp-release:4.11.13...
level=info msg=8c220d6a95925175d0e1121195816ecd2b89f9c518f95a98f722dd6383558e34
level=info msg=ERROR: release image arch arm64 does not match host arch amd64
```