### PR TITLE
Remove render machine config which have pull secret info

### DIFF
--- a/snc.sh
+++ b/snc.sh
@@ -254,6 +254,6 @@ wait_till_cluster_stable openshift-marketplace
 retry ${OC} delete pod --field-selector=status.phase==Succeeded --all-namespaces
 
 # Delete outdated rendered master/worker machineconfigs and just keep the latest one
-${OC} get mc --sort-by=.metadata.creationTimestamp --no-headers -oname | grep rendered-master | head -n -1 | xargs -t ${OC} delete
+${OC} get mc --sort-by=.metadata.creationTimestamp --no-headers -oname | grep rendered-master | head -n -2 | xargs -t ${OC} delete
 ${OC} get mc --sort-by=.metadata.creationTimestamp --no-headers -oname | grep rendered-worker | head -n -1 | xargs -t ${OC} delete
 


### PR DESCRIPTION
Right now we are removing the machineconfig which is generated after pull secret changes happen and machine config operator fails to reconcile in case of openshift-4.12 because as soon as we delete the pull secret it is not able to pull image to inspect the content which is added

- https://github.com/openshift/machine-config-operator/commit/1671a453f1a95ff9e3720719c4151f289e2fdd0c

```
I1123 10:31:08.119905    4150 run.go:19] Running: podman pull -q --authfile /var/lib/kubelet/config.json quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:ffa3568233298408421ff7da60e5c594fb63b2551c6ab53843eb51c8cf6838ba
Error: initializing source docker://quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:ffa3568233298408421ff7da60e5c594fb63b2551c6ab53843eb51c8cf6838ba: reading manifest sha256:ffa3568233298408421ff7da60e5c594fb63b2551c6ab53843eb51c8cf6838ba in quay.io/openshift-release-dev/ocp-v4.0-art-dev: unauthorized: access to the requested resource is not authorized
```

This is still a workaround because ideally mco should able to reconcile in case there is no pull secret on the cluster (OKD usecase).

In this PR we are not removing one of the older machineconfig which MCO wants to reconcile from and not able to because of podman pull issue so when crc provision the cluster it also add the correct pull secret and then MCO reconcile happen.

Upstream Jira issue: https://issues.redhat.com/browse/OCPBUGS-4049