### PR TITLE
Install qemu-guest-agent in the bundle

### DIFF
--- a/createdisk-library.sh
+++ b/createdisk-library.sh
@@ -206,6 +206,22 @@ function prepare_hyperV() {
             echo 'CONST{virt}=="microsoft", RUN{builtin}+="kmod load hv_sock"' > /etc/udev/rules.d/90-crc-vsock.rules
 EOF
 }
+function prepare_qemu_guest_agent() {
+    local vm_ip=$1
+
+    # f36 default selinux policy blocks usage of qemu-guest-agent over vsock
+    # checkpolicy
+    /usr/bin/checkmodule -M -m -o qemuga-vsock.mod qemuga-vsock.te
+    # policycoreutils
+    /usr/bin/semodule_package -o qemuga-vsock.pp -m qemuga-vsock.mod
+
+    ${SCP} qemuga-vsock.pp core@${vm_ip}:
+    ${SSH} core@${vm_ip} 'sudo semodule -i qemuga-vsock.pp && rm qemuga-vsock.pp'
+    ${SCP} qemu-guest-agent.service core@${vm_ip}:
+    ${SSH} core@${vm_ip} 'sudo mv -Z qemu-guest-agent.service /etc/systemd/system/'
+    ${SSH} core@${vm_ip} 'sudo systemctl daemon-reload'
+    ${SSH} core@${vm_ip} 'sudo systemctl enable qemu-guest-agent.service'
+}
 
 function generate_vfkit_bundle {
     local srcDir=$1

--- a/createdisk.sh
+++ b/createdisk.sh
@@ -55,6 +55,8 @@ if [ -n "${SNC_GENERATE_WINDOWS_BUNDLE}" ]; then
     prepare_hyperV api.${CRC_VM_NAME}.${BASE_DOMAIN}
 fi
 
+prepare_qemu_guest_agent api.${CRC_VM_NAME}.${BASE_DOMAIN}
+
 # Add gvisor-tap-vsock and crc-dnsmasq services
 ${SSH} core@api.${CRC_VM_NAME}.${BASE_DOMAIN} 'sudo bash -x -s' <<EOF
   podman create --name=gvisor-tap-vsock --privileged --net=host -v /etc/resolv.conf:/etc/resolv.conf -it quay.io/crcont/gvisor-tap-vsock:latest

--- a/qemu-guest-agent.service
+++ b/qemu-guest-agent.service
@@ -1,0 +1,17 @@
+[Unit]
+Description=QEMU Guest Agent
+IgnoreOnIsolate=True
+
+[Service]
+UMask=0077
+EnvironmentFile=/etc/sysconfig/qemu-ga
+ExecStart=/usr/bin/qemu-ga \
+  --method=vsock-listen \
+  --path=3:1234 \
+  --blacklist=${BLACKLIST_RPC} \
+  -F${FSFREEZE_HOOK_PATHNAME}
+Restart=always
+RestartSec=0
+
+[Install]
+WantedBy=default.target

--- a/qemuga-vsock.te
+++ b/qemuga-vsock.te
@@ -1,0 +1,9 @@
+module qemuga-vsock 1.0;
+
+require {
+	type virt_qemu_ga_t;
+	class vsock_socket { bind create getattr listen accept read write };
+}
+
+#============= virt_qemu_ga_t ==============
+allow virt_qemu_ga_t self:vsock_socket { bind create getattr listen accept read write };


### PR DESCRIPTION
It will be used to sync the time of the guest on macOS when the system gets out of sleep.

A selinux policy change is needed to be allowed to use it over virtio-vsock.

To apply it (
https://relativkreativ.at/articles/how-to-compile-a-selinux-policy-package )
checkmodule -M -m -o qemuga-vsock.mod qemuga-vsock.te semodule_package -o qemuga-vsock.pp -m qemuga-vsock.mod semodule -i qemuga-vsock.pp