### PR TITLE
Pick M1 kernel from rhel9.1

### DIFF
--- a/repos/rhel9-internal.repo
+++ b/repos/rhel9-internal.repo
@@ -1,5 +1,5 @@
 [rhel-9.0-baseos]
 name=rhel9 baseos
-baseurl=https://rhsm-pulp.corp.redhat.com/content/eus/rhel9/9.0/$basearch/baseos/os/
+baseurl=https://rhsm-pulp.corp.redhat.com/content/eus/rhel9/9.1/$basearch/baseos/os/
 enabled=1
 gpgcheck=0


### PR DESCRIPTION
With RHEL 9.1 officially released, we can get the kernel from there, it
should be newer than the ones in RHEL 9.0