### PR TITLE
build qemu-ga selinux policy package inside the guest

### DIFF
--- a/createdisk-library.sh
+++ b/createdisk-library.sh
@@ -210,13 +210,11 @@ function prepare_qemu_guest_agent() {
     local vm_ip=$1
 
     # f36 default selinux policy blocks usage of qemu-guest-agent over vsock
-    # checkpolicy
-    /usr/bin/checkmodule -M -m -o qemuga-vsock.mod qemuga-vsock.te
-    # policycoreutils
-    /usr/bin/semodule_package -o qemuga-vsock.pp -m qemuga-vsock.mod
+    ${SCP} qemuga-vsock.te core@${vm_ip}:
+    ${SSH} core@${vm_ip} '/usr/bin/checkmodule -M -m -o qemuga-vsock.mod qemuga-vsock.te'
+    ${SSH} core@${vm_ip} '/usr/bin/semodule_package -o qemuga-vsock.pp -m qemuga-vsock.mod'
 
-    ${SCP} qemuga-vsock.pp core@${vm_ip}:
-    ${SSH} core@${vm_ip} 'sudo semodule -i qemuga-vsock.pp && rm qemuga-vsock.pp'
+    ${SSH} core@${vm_ip} 'sudo semodule -i qemuga-vsock.pp && rm qemuga-vsock.pp qemuga-vsock.mod qemuga-vsock.te'
     ${SCP} qemu-guest-agent.service core@${vm_ip}:
     ${SSH} core@${vm_ip} 'sudo mv -Z qemu-guest-agent.service /etc/systemd/system/'
     ${SSH} core@${vm_ip} 'sudo systemctl daemon-reload'


### PR DESCRIPTION
the version of selinux policy kit where the package is built should be the same in the target machine where the package is installed in our case the host where we are building is rhel9 and the targets os is rhel8, where it fails to install with the following error:

```
libsemanage.semanage_pipe_data: Child process /usr/libexec/selinux/hll/pp failed with code: 255. (No such file or directory).
qemuga-vsock: libsepol.policydb_read: policydb module version 20 does not match my version range 4-19
qemuga-vsock: libsepol.sepol_module_package_read: invalid module in module package (at section 0)
qemuga-vsock: Failed to read policy package
libsemanage.semanage_direct_commit: Failed to compile hll files into cil files.
 (No such file or directory).
semodule:  Failed!
```