### PR TITLE
Install checkpolicy package to fcos to execute checkmodule command

### DIFF
--- a/createdisk-library.sh
+++ b/createdisk-library.sh
@@ -209,6 +209,10 @@ EOF
 function prepare_qemu_guest_agent() {
     local vm_ip=$1
 
+    if [[ ${BASE_OS} = "fedora-coreos" ]]; then
+        install_additional_packages ${vm_ip} checkpolicy
+    fi
+
     # f36 default selinux policy blocks usage of qemu-guest-agent over vsock
     ${SCP} qemuga-vsock.te core@${vm_ip}:
     ${SSH} core@${vm_ip} '/usr/bin/checkmodule -M -m -o qemuga-vsock.mod qemuga-vsock.te'


### PR DESCRIPTION
After b13f44cfa09ca65c2d68665dc45225f1030ce2dc, qemu-ga selinux policy built inside the guest which require checkmodule command to check and compile selinux policy. Currently RHCOS have checkpolicy package installed by default but it is not part of FCOS. This patch install the checkpolicy package in case of OKD bundle creation.