### PR TITLE
qemuga: Ensure selinux policy module is rhel8-compatible

### DIFF
--- a/createdisk-library.sh
+++ b/createdisk-library.sh
@@ -210,11 +210,13 @@ function prepare_qemu_guest_agent() {
     local vm_ip=$1
 
     # f36 default selinux policy blocks usage of qemu-guest-agent over vsock
-    ${SCP} qemuga-vsock.te core@${vm_ip}:
-    ${SSH} core@${vm_ip} '/usr/bin/checkmodule -M -m -o qemuga-vsock.mod qemuga-vsock.te'
-    ${SSH} core@${vm_ip} '/usr/bin/semodule_package -o qemuga-vsock.pp -m qemuga-vsock.mod'
+    # checkpolicy
+    /usr/bin/checkmodule -M -m -o qemuga-vsock.mod qemuga-vsock.te
+    # policycoreutils
+    /usr/bin/semodule_package -o qemuga-vsock.pp -m qemuga-vsock.mod
 
-    ${SSH} core@${vm_ip} 'sudo semodule -i qemuga-vsock.pp && rm qemuga-vsock.pp qemuga-vsock.mod qemuga-vsock.te'
+    ${SCP} qemuga-vsock.pp core@${vm_ip}:
+    ${SSH} core@${vm_ip} 'sudo semodule -i qemuga-vsock.pp && rm qemuga-vsock.pp'
     ${SCP} qemu-guest-agent.service core@${vm_ip}:
     ${SSH} core@${vm_ip} 'sudo mv -Z qemu-guest-agent.service /etc/systemd/system/'
     ${SSH} core@${vm_ip} 'sudo systemctl daemon-reload'


### PR DESCRIPTION
RHEL8 only supports policy modules up to version 19, while fedora and rhel9
use newer versions. When building on the host, we need to make sure the
policy module we build is compatible with rhel8 which is what the openshift
bundles use as a base OS.