### PR TITLE
build-patched-kao-kcmo-images.sh improvements

### DIFF
--- a/build-patched-kao-kcmo-images.sh
+++ b/build-patched-kao-kcmo-images.sh
@@ -44,7 +44,7 @@ else
     if test -n "${OPENSHIFT_RELEASE_VERSION}"; then
         echo "Using release ${OPENSHIFT_RELEASE_VERSION} from the mirror"
     else
-        echo "Unable to determine an OpenShift release version.  You may want to set the OPENSHIFT_VERSION environment variable explicitly."
+        echo "Unable to determine an OpenShift release version. You may want to set the OPENSHIFT_VERSION environment variable explicitly."
         exit 1
     fi
 fi

--- a/build-patched-kao-kcmo-images.sh
+++ b/build-patched-kao-kcmo-images.sh
@@ -52,8 +52,14 @@ else
     fi
 fi
 
+function release_image_for_arch() {
+     local arch=$1
+     local mirror="https://mirror.openshift.com/pub/openshift-v4/${arch}/clients/ocp"
+     curl -L "${mirror}/${OPENSHIFT_RELEASE_VERSION}/release.txt" 2>/dev/null| sed -n 's/^Pull From: //p'
+}
+
 if test -z "${OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE-}"; then
-    OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE="$(curl -L "${MIRROR}/${OPENSHIFT_RELEASE_VERSION}/release.txt" | sed -n 's/^Pull From: //p')"
+    OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE="$(release_image_for_arch $ARCH)"
 elif test -n "${OPENSHIFT_VERSION-}"; then
     echo "Both OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE and OPENSHIFT_VERSION are set, OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE will take precedence"
     echo "OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE: $OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE"

--- a/build-patched-kao-kcmo-images.sh
+++ b/build-patched-kao-kcmo-images.sh
@@ -59,8 +59,16 @@ fi
 echo "Setting OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE to ${OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE}"
 
 mkdir -p openshift-clients/linux
-curl -L "${MIRROR}/${OPENSHIFT_RELEASE_VERSION}/openshift-client-linux-${OPENSHIFT_RELEASE_VERSION}.tar.gz" | tar -zx -C openshift-clients/linux oc
 OC=./openshift-clients/linux/oc
+if [ -f "$OC" ]; then
+	current_oc_version=$(${OC} version --client -o json |jq -r .releaseClientVersion)
+fi
+echo "OC version: ${current_oc_version-}"
+if [ ${current_oc_version-} = ${OPENSHIFT_RELEASE_VERSION} ]; then
+    echo "No need to download oc, local oc is already version ${OPENSHIFT_RELEASE_VERSION}"
+else
+    curl -L "${MIRROR}/${OPENSHIFT_RELEASE_VERSION}/openshift-client-linux-${OPENSHIFT_RELEASE_VERSION}.tar.gz" | tar -zx -C openshift-clients/linux oc
+fi
 
 function patch_and_push_image() {
     local image_name=$1

--- a/build-patched-kao-kcmo-images.sh
+++ b/build-patched-kao-kcmo-images.sh
@@ -35,7 +35,8 @@ function check_pull_secret() {
 
 check_pull_secret
 
-MIRROR=${MIRROR:-https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp}
+ARCH=$(uname -m)
+MIRROR=${MIRROR:-https://mirror.openshift.com/pub/openshift-v4/$ARCH/clients/ocp}
 
 # If user defined the OPENSHIFT_VERSION environment variable then use it.
 if test -n "${OPENSHIFT_VERSION-}"; then

--- a/build-patched-kao-kcmo-images.sh
+++ b/build-patched-kao-kcmo-images.sh
@@ -98,6 +98,34 @@ function patch_and_push_image() {
     skopeo copy --dest-authfile ${OPENSHIFT_PULL_SECRET_PATH} --all docker://registry-proxy.engineering.redhat.com/rh-osbs/openshift-crc-${image_name}:${version}-${release} docker://quay.io/crcont/openshift-crc-${image_name}:${openshift_version}
 }
 
+function create_patched_release_image_for_arch() {
+    local upstream_registry=$1
+    local arch=$2
+    local release_image="$(release_image_for_arch ${arch})"
+
+    # As of now, `oc adm release new` is not able to parse images which have
+    # multiple arch manifest file so we first need to get the digest of the
+    # image for ${yq_arch} and then use that digest with `oc adm release new`_
+    kao_image_digest=$(${OC} image info -a ${OPENSHIFT_PULL_SECRET_PATH} ${upstream_registry}/openshift-crc-cluster-kube-apiserver-operator:${openshift_version} --filter-by-os=linux/${arch} -ojson | jq -r .digest)
+    kcmo_image_digest=$(${OC} image info -a ${OPENSHIFT_PULL_SECRET_PATH} ${upstream_registry}/openshift-crc-cluster-kube-controller-manager-operator:${openshift_version} --filter-by-os=linux/${arch} -ojson | jq -r .digest)
+
+    ${OC} adm release new -a ${OPENSHIFT_PULL_SECRET_PATH} --from-release=${release_image} \
+	    cluster-kube-apiserver-operator=${upstream_registry}/openshift-crc-cluster-kube-apiserver-operator@${kao_image_digest} \
+	    cluster-kube-controller-manager-operator=${upstream_registry}/openshift-crc-cluster-kube-controller-manager-operator@${kcmo_image_digest} \
+	    --to-image=${upstream_registry}/ocp-release:${openshift_version}-${arch}
+}
+
+function create_new_release_with_patched_images() {
+    local upstream_registry="quay.io/crcont"
+
+    podman manifest create ${upstream_registry}/ocp-release:${openshift_version}
+    for arch in amd64 arm64; do \
+        create_patched_release_image_for_arch ${upstream_registry} ${arch}
+        podman manifest add ${upstream_registry}/ocp-release:${openshift_version} docker://${upstream_registry}/ocp-release:${openshift_version}-${arch}
+      done
+    podman manifest push --all ${upstream_registry}/ocp-release:${openshift_version}  docker://${upstream_registry}/ocp-release:${openshift_version}
+}
+
 function update_base_image() {
     local brew_repo=$1
     local base_image=$2
@@ -122,6 +150,7 @@ openshift_version=$(${OC} adm release info -a ${OPENSHIFT_PULL_SECRET_PATH} ${OP
 
 patch_and_push_image cluster-kube-apiserver-operator
 patch_and_push_image cluster-kube-controller-manager-operator
+create_new_release_with_patched_images
 
 base_image=$(grep "^FROM openshift/ose-base" crc-cluster-kube-apiserver-operator/Dockerfile | sed 's/^FROM //')
 

--- a/snc-library.sh
+++ b/snc-library.sh
@@ -10,7 +10,26 @@ function preflight_failure() {
         fi
 }
 
+function check_oc_version() {
+    local current_oc_version=
+    if [ -f "$OC" ]; then
+       current_oc_version=$(${OC} version --client -o json  |jq -r .releaseClientVersion)
+    fi
+
+    [ ${current_oc_version} = ${OPENSHIFT_RELEASE_VERSION} ]
+}
+
 function download_oc() {
+    local current_oc_version=
+
+    if [ -f "$OC" ]; then
+        current_oc_version=$(${OC} version --client -o json  |jq -r .releaseClientVersion)
+        if [ ${current_oc_version} = ${OPENSHIFT_RELEASE_VERSION} ]; then
+            echo "No need to download oc, local oc is already version ${OPENSHIFT_RELEASE_VERSION}"
+            return
+        fi
+    fi
+
     mkdir -p openshift-clients/linux
     curl -L "${MIRROR}/${OPENSHIFT_RELEASE_VERSION}/openshift-client-linux-${OPENSHIFT_RELEASE_VERSION}.tar.gz" | tar -zx -C openshift-clients/linux oc
 

--- a/snc.sh
+++ b/snc.sh
@@ -54,8 +54,8 @@ else
 fi
 
 # Download the oc binary for specific OS environment
-download_oc
 OC=./openshift-clients/linux/oc
+download_oc
 
 if test -z "${OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE-}"; then
     OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE="$(curl -L "${MIRROR}/${OPENSHIFT_RELEASE_VERSION}/release.txt" | sed -n 's/^Pull From: //p')"

--- a/snc.sh
+++ b/snc.sh
@@ -48,7 +48,7 @@ else
     if test -n "${OPENSHIFT_RELEASE_VERSION}"; then
         echo "Using release ${OPENSHIFT_RELEASE_VERSION} from the latest mirror"
     else
-        echo "Unable to determine an OpenShift release version.  You may want to set the OPENSHIFT_VERSION environment variable explicitly."
+        echo "Unable to determine an OpenShift release version. You may want to set the OPENSHIFT_VERSION environment variable explicitly."
         exit 1
     fi
 fi

--- a/snc.sh
+++ b/snc.sh
@@ -75,8 +75,8 @@ fi
 
 if [[ ${USE_PATCHED_RELEASE_IMAGE} == "enabled" ]]
 then
-   echo "Creating a new image with patched KAO/KCMO images"
-   create_new_release_with_patched_images
+   echo "Using release image with patched KAO/KCMO images"
+   OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE=quay.io/crcont/ocp-release:${OPENSHIFT_RELEASE_VERSION}-${yq_ARCH}
    echo "OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE set to ${OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE}"
 fi
 


### PR DESCRIPTION
This PR adds 2 new features to the script:
- it automatically regenerates crc-dnsmasq and crc-routes-controller so that they use the same base image as the rest of the cluster
- it builds a patched release image so that it's only done once