### PR TITLE
Add retry to get machine config in case apiserver not respond at first

### DIFF
--- a/snc.sh
+++ b/snc.sh
@@ -254,6 +254,7 @@ wait_till_cluster_stable openshift-marketplace
 retry ${OC} delete pod --field-selector=status.phase==Succeeded --all-namespaces
 
 # Delete outdated rendered master/worker machineconfigs and just keep the latest one
-${OC} get mc --sort-by=.metadata.creationTimestamp --no-headers -oname | grep rendered-master | head -n -1 | xargs -t ${OC} delete
-${OC} get mc --sort-by=.metadata.creationTimestamp --no-headers -oname | grep rendered-worker | head -n -1 | xargs -t ${OC} delete
+mc_name=$(retry ${OC} get mc --sort-by=.metadata.creationTimestamp --no-headers -oname)
+echo "${mc_name}" | grep rendered-master | head -n -1 | xargs -t ${OC} delete
+echo "${mc_name}" | grep rendered-worker | head -n -1 | xargs -t ${OC} delete
 


### PR DESCRIPTION
We are not sure at what time apiserver became unavailable or goes to reconcile state. This patch add retry function in case first time command execution not successful and fix following issue which occur time to time on the CI

```
+ ./openshift-clients/linux/oc get mc --sort-by=.metadata.creationTimestamp --no-headers -oname
+ grep rendered-master
+ head -n -2
+ xargs -t ./openshift-clients/linux/oc delete
./openshift-clients/linux/oc delete
error: You must provide one or more resources by argument or filename.
```