### PR TITLE
Misc changes for cert approval and validating

### DIFF
--- a/snc-library.sh
+++ b/snc-library.sh
@@ -188,17 +188,16 @@ function renew_certificates() {
 
     start_vm ${vm_prefix}
 
-    # Retry 10 times to make sure kubelet certs are rotated correctly.
+    # Loop until the kubelet certs are valid for a month
     i=0
-    while [ $i -lt 10 ]; do
+    while [ $i -lt 60 ]; do
         if ! ${SSH} core@api.${CRC_VM_NAME}.${BASE_DOMAIN} -- sudo openssl x509 -checkend 2160000 -noout -in /var/lib/kubelet/pki/kubelet-client-current.pem ||
 		! ${SSH} core@api.${CRC_VM_NAME}.${BASE_DOMAIN} -- sudo openssl x509 -checkend 2160000 -noout -in /var/lib/kubelet/pki/kubelet-server-current.pem; then
             retry ${OC} get csr -ojson > certs.json
 	    retry ${OC} adm certificate approve -f certs.json
 	    rm -f certs.json
-	    # Wait until bootstrap csr request is generated with 10 min timeout
-	    echo "Retry loop $i, wait for 60sec before starting next loop"
-            sleep 60
+	    echo "Retry loop $i, wait for 10sec before starting next loop"
+            sleep 10
 	else
             break
         fi


### PR DESCRIPTION
As of now we first approve the first pending csr for
kube-apiserver-client-kubelet and then approve kubelet-serving one.
On the CI it is observed that as soon as we approve kube-apiserver-client-kubelet
csr (csr-qc8c7), another one is create with same signer name (csr-c28jv) and kubelet-serving not
created until this one is also approved.
```
$ oc get csr
NAME                                             AGE     SIGNERNAME                                    REQUESTOR                                                                         REQUESTEDDURATION   CONDITION
csr-b4gb2                                        24h     kubernetes.io/kube-apiserver-client-kubelet   system:serviceaccount:openshift-machine-config-operator:node-bootstrapper         <none>              Approved,Issued
csr-c28jv                                        3m19s   kubernetes.io/kube-apiserver-client-kubelet   system:serviceaccount:openshift-machine-config-operator:node-bootstrapper         <none>              Pending
csr-f9f7d                                        24h     kubernetes.io/kube-apiserver-client-kubelet   system:serviceaccount:openshift-machine-config-operator:node-bootstrapper         <none>              Approved,Issued
csr-mrdqg                                        24h     kubernetes.io/kubelet-serving                 system:node:crc-zcb9n-master-0                                                    <none>              Approved,Issued
csr-qc8c7                                        8m1s    kubernetes.io/kube-apiserver-client-kubelet   system:serviceaccount:openshift-machine-config-operator:node-bootstrapper         <none>              Approved
system:openshift:openshift-authenticator-k58qx   24h     kubernetes.io/kube-apiserver-client           system:serviceaccount:openshift-authentication-operator:authentication-operator   <none>              Approved,Issued
```

Using this PR we change the logic of iterating to csr request and
approve them to just approve all the csr request until the kubelet
client/server certs are vaild for a month. At the cluster
provision time approving csr request bindly doesn't have any security
implications.