### PR TITLE
macos: Install older kernel

### DIFF
--- a/createdisk-library.sh
+++ b/createdisk-library.sh
@@ -177,6 +177,23 @@ function install_additional_packages() {
     fi
 }
 
+function downgrade_kernel() {
+    # workaround https://github.com/crc-org/vfkit/issues/11 on macOS
+    local vm_ip=$1
+    local arch=$2
+    case $arch in
+         amd64)
+            ${SSH} core@${vm_ip} "curl -L -O https://kojipkgs.fedoraproject.org/packages/kernel/5.19.17/300.fc37/x86_64/kernel-5.19.17-300.fc37.x86_64.rpm -L -O https://kojipkgs.fedoraproject.org/packages/kernel/5.19.17/300.fc37/x86_64/kernel-core-5.19.17-300.fc37.x86_64.rpm -L -O https://kojipkgs.fedoraproject.org/packages/kernel/5.19.17/300.fc37/x86_64/kernel-modules-5.19.17-300.fc37.x86_64.rpm"
+	    ;;
+         arm64)
+            ${SSH} core@${vm_ip} "curl -L -O https://kojipkgs.fedoraproject.org//packages/kernel/5.18.19/200.fc36/aarch64/kernel-5.18.19-200.fc36.aarch64.rpm -L -O https://kojipkgs.fedoraproject.org//packages/kernel/5.18.19/200.fc36/aarch64/kernel-core-5.18.19-200.fc36.aarch64.rpm -L -O https://kojipkgs.fedoraproject.org//packages/kernel/5.18.19/200.fc36/aarch64/kernel-modules-5.18.19-200.fc36.aarch64.rpm"
+	    ;;
+    esac
+
+    ${SSH} core@${vm_ip} "sudo rpm-ostree override -C replace *.rpm"
+    ${SSH} core@${vm_ip} "rm *.rpm"
+}
+
 function prepare_cockpit() {
     local vm_ip=$1
 

--- a/createdisk-library.sh
+++ b/createdisk-library.sh
@@ -218,6 +218,7 @@ function generate_vfkit_bundle {
 
     generate_macos_bundle "vfkit" "$@"
 
+    create_qemu_image "$libvirtDestDir" "fedora-coreos-qemu.${ARCH}.qcow2" "${CRC_VM_NAME}.qcow2"
     ${QEMU_IMG} convert -f qcow2 -O raw $srcDir/${CRC_VM_NAME}.qcow2 $destDir/${CRC_VM_NAME}.img
     add_disk_info_to_json_description "${destDir}" "${CRC_VM_NAME}.img" "raw"
 

--- a/createdisk-library.sh
+++ b/createdisk-library.sh
@@ -10,6 +10,34 @@ function get_dest_dir_suffix {
     fi
 }
 
+# This removes extra os tree layers, log files, ... from the image
+function cleanup_vm_image() {
+    local vm_name=$1
+    local vm_ip=$2
+
+    # Shutdown and Start the VM to get the latest ostree layer. If packages
+    # have been added/removed since last boot, the VM will reboot in a different ostree layer.
+    shutdown_vm ${vm_name}
+    start_vm ${vm_name} ${vm_ip}
+
+    # Remove miscellaneous unneeded data from rpm-ostree
+    ${SSH} core@${vm_ip} -- 'sudo rpm-ostree cleanup --rollback --base --repomd'
+
+    # Remove logs.
+    # Note: With `sudo journalctl --rotate --vacuum-time=1s`, it doesn't
+    # remove all the journal logs so separate commands are used here.
+    ${SSH} core@${VM_IP} -- 'sudo journalctl --rotate'
+    ${SSH} core@${VM_IP} -- 'sudo journalctl --vacuum-time=1s'
+    ${SSH} core@${vm_ip} -- 'sudo find /var/log/ -iname "*.log" -exec rm -f {} \;'
+
+    # Shutdown and Start the VM after removing base deployment tree
+    # This is required because kernel commandline changed, namely
+    # ostree=/ostree/boot.1/fedora-coreos/$hash/0 which switches
+    # between boot.0 and boot.1 when cleanup is run
+    shutdown_vm ${vm_name}
+    start_vm ${vm_name} ${vm_ip}
+}
+
 function sparsify {
     local baseDir=$1
     local srcFile=$2

--- a/createdisk.sh
+++ b/createdisk.sh
@@ -45,21 +45,21 @@ start_vm ${CRC_VM_NAME} ${VM_IP}
 ${SSH} core@${VM_IP} -- 'sudo rpm-ostree cleanup --rollback --base --repomd'
 # Shutdown and Start the VM after removing base deployment tree
 # This is required because kernel commandline changed, namely
-# ostree=/ostree/boot.1/fedora-coreos/$hash/0 which switches 
+# ostree=/ostree/boot.1/fedora-coreos/$hash/0 which switches
 # between boot.0 and boot.1 when cleanup is run
 shutdown_vm ${CRC_VM_NAME}
 start_vm ${CRC_VM_NAME} ${VM_IP}
 
 # Only used for macOS bundle generation
 if [ -n "${SNC_GENERATE_MACOS_BUNDLE}" ]; then
-    # Get the rhcos ostree Hash ID
-    ostree_hash=$(${SSH} core@${VM_IP} -- "cat /proc/cmdline | grep -oP \"(?<=${BASE_OS}-).*(?=/vmlinuz)\"")
-
     # Get the rhcos kernel release
     kernel_release=$(${SSH} core@${VM_IP} -- 'uname -r')
 
     # Get the kernel command line arguments
     kernel_cmd_line=$(${SSH} core@${VM_IP} -- 'cat /proc/cmdline')
+
+    # Get the rhcos ostree Hash ID
+    ostree_hash=$(echo ${kernel_cmd_line} | grep -oP "(?<=${BASE_OS}-).*(?=/vmlinuz)")
 
     # SCP the vmlinuz/initramfs from VM to Host in provided folder.
     ${SCP} -r core@${VM_IP}:/boot/ostree/${BASE_OS}-${ostree_hash}/* $INSTALL_DIR


### PR DESCRIPTION
Because of https://github.com/crc-org/vfkit/issues/11 we need to use an 
older kernel with our macOS bundles. This is fixed in macOS 13, but we want
to keep compatibility with macOS 12 for a while.
However, we want to keep using the latest kernel for linux and Windows.
This PR starts by refactoring the bundle generation. Before this PR, the bundle generation process is roughly:
- do various modifications in the VM
- shut down the VM
- use the same VM image for all 3 platforms

After this PR, it will become:
- do various modifications in the VM
- shut it down
- generate the linux/Windows bundles
- restart the VM
- downgrade the kernel
- shut the VM down
- generate the macOS bundle

This makes the bundle generation slower as making the VM image
sparse/converting it/... can be slow, but this allows to keep compatibility
with macOS 12.

This PR uses the latest 5.18 fedora kernel on M1, and latest 5.19 fedora kernel
on Intel mac.