### PR TITLE
Remove csi-snapshot-controller-operator from CVO override

### DIFF
--- a/cvo-overrides-after-first-run.yaml
+++ b/cvo-overrides-after-first-run.yaml
@@ -33,11 +33,6 @@
     unmanaged: true
   - kind: Deployment
     group: apps
-    name: csi-snapshot-controller-operator
-    namespace: openshift-cluster-storage-operator
-    unmanaged: true
-  - kind: Deployment
-    group: apps
     name: cluster-cloud-controller-manager-operator
     namespace: openshift-cloud-controller-manager-operator
     unmanaged: true


### PR DESCRIPTION
Since we are using the capabilites now and it is missed during f6d417c commit.