### PR TITLE
Revert "Remove render machine config which have pull secret info"

### DIFF
--- a/snc.sh
+++ b/snc.sh
@@ -255,6 +255,6 @@ retry ${OC} delete pod --field-selector=status.phase==Succeeded --all-namespaces
 
 # Delete outdated rendered master/worker machineconfigs and just keep the latest one
 mc_name=$(retry ${OC} get mc --sort-by=.metadata.creationTimestamp --no-headers -oname)
-echo "${mc_name}" | grep rendered-master | head -n -2 | xargs -t ${OC} delete
+echo "${mc_name}" | grep rendered-master | head -n -1 | xargs -t ${OC} delete
 echo "${mc_name}" | grep rendered-worker | head -n -1 | xargs -t ${OC} delete
 


### PR DESCRIPTION
This reverts commit 791d8e2cda8042c7fa0ff81187aab6df3b1f46d7.

It is now fixed and available in 4.12.3 and 4.13.0-ec.3
- https://github.com/openshift/machine-config-operator/pull/3526