### PR TITLE
Fix podman static binary for linux which now have arch info

### DIFF
--- a/createdisk-library.sh
+++ b/createdisk-library.sh
@@ -276,8 +276,9 @@ function download_podman() {
     local arch=$2
 
     mkdir -p podman-remote/linux
-    curl -L https://github.com/containers/podman/releases/download/v${version}/podman-remote-static.tar.gz | tar -zx -C podman-remote/linux podman-remote-static
-    mv podman-remote/linux/podman-remote-static podman-remote/linux/podman-remote
+    curl -L https://github.com/containers/podman/releases/download/v${version}/podman-remote-static-linux_${arch}.tar.gz | tar -zx -C podman-remote/linux ./bin/podman-remote-static-linux_${arch}
+    mv podman-remote/linux/bin/podman-remote-static-linux_${arch} podman-remote/linux/podman-remote
+    rm -fr podman-remote/linux/bin
     chmod +x podman-remote/linux/podman-remote
 
     if [ -n "${SNC_GENERATE_MACOS_BUNDLE}" ]; then


### PR DESCRIPTION
podman-remote linux binary now have arch info and binary is placed under bin folder before creating the tarball. We now need to extract it with bin folder and remove it after moving it to correct location.
```
$ curl -L -O https://github.com/containers/podman/releases/download/v4.4.1/podman-remote-static-linux_amd64.tar.gz
$ tar -tf podman-remote-static-linux_amd64.tar.gz
./bin/podman-remote-static-linux_amd64
```

fix #662 