### PR TITLE
replace k8s.gcr.io with registry.k8s.io

### DIFF
--- a/kubevirt-hostpath-provisioner-csi/csi-driver/csi-kubevirt-hostpath-provisioner.yaml
+++ b/kubevirt-hostpath-provisioner-csi/csi-driver/csi-kubevirt-hostpath-provisioner.yaml
@@ -141,7 +141,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: spec.nodeName
-        image: k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.2.0
+        image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.2.0
         imagePullPolicy: IfNotPresent
         name: node-driver-registrar
         resources: {}
@@ -159,7 +159,7 @@ spec:
       - args:
         - --csi-address=/csi/csi.sock
         - --health-port=9898
-        image: k8s.gcr.io/sig-storage/livenessprobe:v2.3.0
+        image: registry.k8s.io/sig-storage/livenessprobe:v2.3.0
         imagePullPolicy: IfNotPresent
         name: liveness-probe
         resources: {}
@@ -194,7 +194,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: spec.nodeName
-        image: k8s.gcr.io/sig-storage/csi-provisioner:v2.2.1
+        image: registry.k8s.io/sig-storage/csi-provisioner:v2.2.1
         imagePullPolicy: IfNotPresent
         name: csi-provisioner
         resources: {}

--- a/kubevirt-hostpath-provisioner-csi/csi-driver/kustomization.yaml
+++ b/kubevirt-hostpath-provisioner-csi/csi-driver/kustomization.yaml
@@ -4,12 +4,12 @@ images:
   - name: quay.io/kubevirt/hostpath-csi-driver
     newName: quay.io/crcont/hostpath-csi-driver
     newTag: v4.11.0
-  - name: k8s.gcr.io/sig-storage/csi-node-driver-registrar
+  - name: registry.k8s.io/sig-storage/csi-node-driver-registrar
     newName: registry.redhat.io/openshift4/ose-csi-node-driver-registrar
     newTag: latest
-  - name: k8s.gcr.io/sig-storage/livenessprobe
+  - name: registry.k8s.io/sig-storage/livenessprobe
     newName: registry.redhat.io/openshift4/ose-csi-livenessprobe
     newTag: latest
-  - name: k8s.gcr.io/sig-storage/csi-provisioner
+  - name: registry.k8s.io/sig-storage/csi-provisioner
     newName: registry.redhat.io/openshift4/ose-csi-external-provisioner
     newTag: latest


### PR DESCRIPTION
the community kubrenetes registry will be depreceted and is replace with registry.k8s.io more details in https://kubernetes.io/blog/2023/02/06/k8s-gcr-io-freeze-announcement/