### PR TITLE
Use ${SNC_PRODUCT_NAME}.${BASE_DOMAIN} instead of crc.testing

### DIFF
--- a/snc.sh
+++ b/snc.sh
@@ -229,7 +229,7 @@ ${SSH} core@api.${SNC_PRODUCT_NAME}.${BASE_DOMAIN} -- 'sudo mv /home/core/kubeco
 
 # Add exposed registry CA to VM
 retry ${OC} extract secret/router-ca --keys=tls.crt -n openshift-ingress-operator --confirm
-retry ${OC} create configmap registry-certs --from-file=default-route-openshift-image-registry.apps-crc.testing=tls.crt -n openshift-config
+retry ${OC} create configmap registry-certs --from-file=default-route-openshift-image-registry.apps-${SNC_PRODUCT_NAME}.${BASE_DOMAIN}=tls.crt -n openshift-config
 retry ${OC} patch image.config.openshift.io cluster -p '{"spec": {"additionalTrustedCA": {"name": "registry-certs"}}}' --type merge
 
 # Remove the machine config for chronyd to make it active again


### PR DESCRIPTION
This will create the currect registry-certs configmap incase the user changed the default SNC_PRODUCT_NAME or BASE_DOMAIN