### PR TITLE
Should use config.yaml instead config.yaml.default

### DIFF
--- a/createdisk.sh
+++ b/createdisk.sh
@@ -75,7 +75,7 @@ EOF
     ${SSH} core@${VM_IP} -- sudo rm -f /etc/crio/openshift-pull-secret
     # Copy the sample microshift config and update the base domain with crc base domain
     ${SSH} core@${VM_IP} -- sudo cp /etc/microshift/config.yaml.default /etc/microshift/config.yaml
-    ${SSH} core@${VM_IP} -- "sudo sed -i 's/#baseDomain: .*/baseDomain: ${SNC_PRODUCT_NAME}.${BASE_DOMAIN}/g' /etc/microshift/config.yaml.default"
+    ${SSH} core@${VM_IP} -- "sudo sed -i 's/#baseDomain: .*/baseDomain: ${SNC_PRODUCT_NAME}.${BASE_DOMAIN}/g' /etc/microshift/config.yaml"
 fi
 
 # Remove audit logs


### PR DESCRIPTION
It was by mistake added during 9bd725ca9ede737e1c98a8c42702bb88bcfa7d64 where it should be the config.yaml