### PR TITLE
Use podman machine marker instead deprecated enabled machine config

### DIFF
--- a/fcos-config.yaml
+++ b/fcos-config.yaml
@@ -112,13 +112,10 @@ storage:
          [containers]
          netns="bridge"
          rootless_networking="cni"
-      # Set machine_enabled to true to indicate we're in VM
-    - path: /etc/containers/containers.conf
+      # Create empty file as machine marker for podman
+      # https://github.com/containers/common/blob/main/pkg/machine/machine.go
+    - path: /etc/containers/podman-machine
       mode: 0644
-      contents:
-        inline: |
-          [engine]
-          machine_enabled=true
     - path: /etc/NetworkManager/dispatcher.d/pre-up.d/gvisor-tap-vsock-tap-device.sh
       mode: 0755
       contents:


### PR DESCRIPTION
With https://github.com/containers/common/commit/0db57c8ff1272546f13100d464674366d98323a9 `machine_enabled=true/false` setting in the containers.conf is deprecated and now there is `podman-machine` marker file, which is used for this setting.

- https://github.com/containers/common/blob/main/pkg/machine/machine.go#L21