### PR TITLE
Use podman machine marker instead deprecated enabled machine config

### DIFF
--- a/podman_changes.ks
+++ b/podman_changes.ks
@@ -15,10 +15,7 @@ rootless_networking="cni"
 EOF
 chown -R core:core /home/core/.config/containers
 
-tee /etc/containers/containers.conf <<EOF
-[engine]
-machine_enabled=true
-EOF
+touch /etc/containers/podman-machine
 
 tee /etc/containers/registries.conf.d/999-podman-machine.conf <<EOF
 unqualified-search-registries=["docker.io"]


### PR DESCRIPTION
With https://github.com/containers/common/commit/0db57c8ff1272546f13100d464674366d98323a9 `machine_enabled=true/false` setting in the containers.conf is deprecated and now there is `podman-machine` marker file, which is used for this setting.

- https://github.com/containers/common/blob/main/pkg/machine/machine.go#L21