### PR TITLE
Update the kernel version to 5.19.16-301 because 5.19.17-300 not avai…

### DIFF
--- a/createdisk-library.sh
+++ b/createdisk-library.sh
@@ -183,7 +183,7 @@ function downgrade_kernel() {
     local arch=$2
     case $arch in
          amd64)
-            ${SSH} core@${vm_ip} "curl -L -O https://kojipkgs.fedoraproject.org/packages/kernel/5.19.17/300.fc37/x86_64/kernel-5.19.17-300.fc37.x86_64.rpm -L -O https://kojipkgs.fedoraproject.org/packages/kernel/5.19.17/300.fc37/x86_64/kernel-core-5.19.17-300.fc37.x86_64.rpm -L -O https://kojipkgs.fedoraproject.org/packages/kernel/5.19.17/300.fc37/x86_64/kernel-modules-5.19.17-300.fc37.x86_64.rpm"
+            ${SSH} core@${vm_ip} "curl -L -O https://kojipkgs.fedoraproject.org//packages/kernel/5.19.16/301.fc37/x86_64/kernel-5.19.16-301.fc37.x86_64.rpm -L -O https://kojipkgs.fedoraproject.org//packages/kernel/5.19.16/301.fc37/x86_64/kernel-core-5.19.16-301.fc37.x86_64.rpm -L -O https://kojipkgs.fedoraproject.org//packages/kernel/5.19.16/301.fc37/x86_64/kernel-modules-5.19.16-301.fc37.x86_64.rpm"
 	    ;;
          arm64)
             ${SSH} core@${vm_ip} "curl -L -O https://kojipkgs.fedoraproject.org//packages/kernel/5.18.19/200.fc36/aarch64/kernel-5.18.19-200.fc36.aarch64.rpm -L -O https://kojipkgs.fedoraproject.org//packages/kernel/5.18.19/200.fc36/aarch64/kernel-core-5.18.19-200.fc36.aarch64.rpm -L -O https://kojipkgs.fedoraproject.org//packages/kernel/5.18.19/200.fc36/aarch64/kernel-modules-5.18.19-200.fc36.aarch64.rpm"


### PR DESCRIPTION
…lable

looks like https://koji.fedoraproject.org/koji/buildinfo?buildID=2080019 is deleted which we were using so now need to use older version of kernel https://koji.fedoraproject.org/koji/buildinfo?buildID=2079160 which is still available.