### PR TITLE
Enable podman service for user level

### DIFF
--- a/createdisk.sh
+++ b/createdisk.sh
@@ -55,8 +55,9 @@ if [ ${BUNDLE_TYPE} != "microshift" ]; then
     ${SSH} core@${VM_IP} -- sudo systemctl stop kubelet
 fi
 
-# Enable the podman.socket service for API V2
+# Enable the system and user level  podman.socket service for API V2
 ${SSH} core@${VM_IP} -- sudo systemctl enable podman.socket
+${SSH} core@${VM_IP} -- systemctl --user enable podman.socket
 
 if [ ${BUNDLE_TYPE} == "microshift" ]; then
     # Pull openshift release images because as part of microshift bundle creation we


### PR DESCRIPTION
Looks like till 4.12 the podman.socket enabled by default for the user because it is vendor `preset: enabled` so when this package is installed it is enabled by default but it is not case for 4.13

4.12 bundle side
```
$ systemctl --user status podman.socket
● podman.socket - Podman API Socket
   Loaded: loaded (/usr/lib/systemd/user/podman.socket; enabled; vendor preset: enabled)
   Active: active (listening) since Fri 2023-03-31 15:37:43 UTC; 1min 41s ago
     Docs: man:podman-system-service(1)
   Listen: /run/user/1000/podman/podman.sock (Stream)
   CGroup: /user.slice/user-1000.slice/user@1000.service/podman.socket
```

4.13 bundle side (which is based on RHEL-9)
```
$ systemctl --user status podman.socket
○ podman.socket - Podman API Socket
     Loaded: loaded (/usr/lib/systemd/user/podman.socket; disabled; preset: disabled)
     Active: inactive (dead)
   Triggers: ● podman.service
       Docs: man:podman-system-service(1)
     Listen: /run/user/1000/podman/podman.sock (Stream)
```

With this PR we are explicit enable podman socket service for user level.