### PR TITLE
Stop using github.com/code-ready/crc

### DIFF
--- a/ci_microshift.sh
+++ b/ci_microshift.sh
@@ -7,10 +7,9 @@ sudo yum install -y make golang
 ./shellcheck.sh
 ./microshift.sh
 
-# Run createdisk script
 # Set the zstd compression level to 10 to have faster
-# compression.
-export CRC_ZSTD_EXTRA_FLAGS="-10 --long"
+# compression while keeping a reasonable bundle size.
+export CRC_ZSTD_EXTRA_FLAGS="-10"
 ./createdisk.sh crc-tmp-install-data
 
 git clone https://github.com/code-ready/crc.git

--- a/ci_microshift.sh
+++ b/ci_microshift.sh
@@ -12,7 +12,7 @@ sudo yum install -y make golang
 export CRC_ZSTD_EXTRA_FLAGS="-10"
 ./createdisk.sh crc-tmp-install-data
 
-git clone https://github.com/code-ready/crc.git
+git clone https://github.com/crc-org/crc.git
 pushd crc
 make cross
 sudo mv out/linux-amd64/crc /usr/local/bin/


### PR DESCRIPTION
This was re-added in the commit introducing ci_microshift.sh in spite of being pointed out during PR review.