### PR TITLE
Revert "Use oc 4.10.x on macOS"

### DIFF
--- a/snc-library.sh
+++ b/snc-library.sh
@@ -35,8 +35,7 @@ function download_oc() {
 
     if [ -n "${SNC_GENERATE_MACOS_BUNDLE}" ]; then
         mkdir -p openshift-clients/mac
-        # workaround for https://github.com/code-ready/snc/issues/576
-        curl -L "https://mirror.openshift.com/pub/openshift-v4/clients/ocp/stable-4.10/openshift-client-mac.tar.gz" | tar -zx -C openshift-clients/mac oc
+        curl -L "${MIRROR}/${OPENSHIFT_RELEASE_VERSION}/openshift-client-mac-${OPENSHIFT_RELEASE_VERSION}.tar.gz" | tar -zx -C openshift-clients/mac oc
     fi
     if [ -n "${SNC_GENERATE_WINDOWS_BUNDLE}" ]; then
         mkdir -p openshift-clients/windows


### PR DESCRIPTION
This reverts commit a5d8d95494cf0c8c65c57036e5b6f0efeee983d4.
 https://bugzilla.redhat.com/show_bug.cgi?id=2097830 is now
fixed. It is available >=4.12.13 which is already in latest channel now.