### PR TITLE
podman: Fix kernel downgrade

### DIFF
--- a/createdisk-library.sh
+++ b/createdisk-library.sh
@@ -178,20 +178,22 @@ function install_additional_packages() {
 }
 
 function downgrade_kernel() {
-    # workaround https://github.com/crc-org/vfkit/issues/11 on macOS
+    # workaround https://github.com/crc-org/vfkit/issues/11 on macOS 11/12
     local vm_ip=$1
     local arch=$2
+    local bodhi_url
     case $arch in
          amd64)
-            ${SSH} core@${vm_ip} "curl -L -O https://kojipkgs.fedoraproject.org//packages/kernel/5.19.16/301.fc37/x86_64/kernel-5.19.16-301.fc37.x86_64.rpm -L -O https://kojipkgs.fedoraproject.org//packages/kernel/5.19.16/301.fc37/x86_64/kernel-core-5.19.16-301.fc37.x86_64.rpm -L -O https://kojipkgs.fedoraproject.org//packages/kernel/5.19.16/301.fc37/x86_64/kernel-modules-5.19.16-301.fc37.x86_64.rpm"
+	    # kernel-5.19.16-301.fc37
+            bodhi_url="https://bodhi.fedoraproject.org/updates/FEDORA-2022-1c6a1ca835"
 	    ;;
          arm64)
-            ${SSH} core@${vm_ip} "curl -L -O https://kojipkgs.fedoraproject.org//packages/kernel/5.18.19/200.fc36/aarch64/kernel-5.18.19-200.fc36.aarch64.rpm -L -O https://kojipkgs.fedoraproject.org//packages/kernel/5.18.19/200.fc36/aarch64/kernel-core-5.18.19-200.fc36.aarch64.rpm -L -O https://kojipkgs.fedoraproject.org//packages/kernel/5.18.19/200.fc36/aarch64/kernel-modules-5.18.19-200.fc36.aarch64.rpm"
+	    # kernel-5.18.19-200.fc36
+            bodhi_url="https://bodhi.fedoraproject.org/updates/FEDORA-2022-5674f93546"
 	    ;;
     esac
 
-    ${SSH} core@${vm_ip} "sudo rpm-ostree override -C replace *.rpm"
-    ${SSH} core@${vm_ip} "rm *.rpm"
+    ${SSH} core@${vm_ip} "sudo rpm-ostree override -C replace ${bodhi_url}"
 }
 
 function prepare_cockpit() {

--- a/createdisk-library.sh
+++ b/createdisk-library.sh
@@ -193,14 +193,18 @@ function downgrade_kernel() {
 	    ;;
     esac
 
-    ${SSH} core@${vm_ip} -- 'sudo sed -i -z s/enabled=0/enabled=1/ /etc/yum.repos.d/fedora.repo'
-    ${SSH} core@${vm_ip} -- 'sudo sed -i -z s/enabled=0/enabled=1/ /etc/yum.repos.d/fedora-updates.repo'
-    ${SSH} core@${vm_ip} -- "sudo rpm-ostree override replace ${bodhi_url}"
-    # kernel-modules-core is new in kernel 6.x packages and does not exist in 5.x kernel packages
-    # it will stay around if we don't explicitly remove it
-    ${SSH} core@${vm_ip} -- 'sudo rpm-ostree override remove kernel-modules-core'
-    ${SSH} core@${vm_ip} -- 'sudo sed -i -z s/enabled=1/enabled=0/ /etc/yum.repos.d/fedora.repo'
-    ${SSH} core@${vm_ip} -- 'sudo sed -i -z s/enabled=1/enabled=0/ /etc/yum.repos.d/fedora-updates.repo'
+
+    ${SSH} core@${vm_ip} 'sudo bash -x -s' <<EOF
+        sed -i -z s/enabled=0/enabled=1/ /etc/yum.repos.d/fedora.repo
+        sed -i -z s/enabled=0/enabled=1/ /etc/yum.repos.d/fedora-updates.repo
+        rpm-ostree override replace "${bodhi_url}"
+	# kernel-modules-core is new in kernel 6.x packages and does not exist
+	# in 5.x kernel packages. It will stay around if we don't explicitly
+	# remove it
+        rpm-ostree override remove kernel-modules-core
+        sed -i -z s/enabled=1/enabled=0/ /etc/yum.repos.d/fedora.repo
+        sed -i -z s/enabled=1/enabled=0/ /etc/yum.repos.d/fedora-updates.repo
+EOF
 }
 
 function prepare_cockpit() {

--- a/createdisk-library.sh
+++ b/createdisk-library.sh
@@ -196,6 +196,9 @@ function downgrade_kernel() {
     ${SSH} core@${vm_ip} -- 'sudo sed -i -z s/enabled=0/enabled=1/ /etc/yum.repos.d/fedora.repo'
     ${SSH} core@${vm_ip} -- 'sudo sed -i -z s/enabled=0/enabled=1/ /etc/yum.repos.d/fedora-updates.repo'
     ${SSH} core@${vm_ip} -- "sudo rpm-ostree override replace ${bodhi_url}"
+    # kernel-modules-core is new in kernel 6.x packages and does not exist in 5.x kernel packages
+    # it will stay around if we don't explicitly remove it
+    ${SSH} core@${vm_ip} -- 'sudo rpm-ostree override remove kernel-modules-core'
     ${SSH} core@${vm_ip} -- 'sudo sed -i -z s/enabled=1/enabled=0/ /etc/yum.repos.d/fedora.repo'
     ${SSH} core@${vm_ip} -- 'sudo sed -i -z s/enabled=1/enabled=0/ /etc/yum.repos.d/fedora-updates.repo'
 }

--- a/createdisk-library.sh
+++ b/createdisk-library.sh
@@ -193,7 +193,11 @@ function downgrade_kernel() {
 	    ;;
     esac
 
-    ${SSH} core@${vm_ip} "sudo rpm-ostree override -C replace ${bodhi_url}"
+    ${SSH} core@${vm_ip} -- 'sudo sed -i -z s/enabled=0/enabled=1/ /etc/yum.repos.d/fedora.repo'
+    ${SSH} core@${vm_ip} -- 'sudo sed -i -z s/enabled=0/enabled=1/ /etc/yum.repos.d/fedora-updates.repo'
+    ${SSH} core@${vm_ip} -- "sudo rpm-ostree override replace ${bodhi_url}"
+    ${SSH} core@${vm_ip} -- 'sudo sed -i -z s/enabled=1/enabled=0/ /etc/yum.repos.d/fedora.repo'
+    ${SSH} core@${vm_ip} -- 'sudo sed -i -z s/enabled=1/enabled=0/ /etc/yum.repos.d/fedora-updates.repo'
 }
 
 function prepare_cockpit() {


### PR DESCRIPTION
This currently fails with dependency issues related to 
missing kernel-uname-r dependencies. 
This PR should fix that. During my testing, first try failed, and second
attempt succeeded, so this must go through CI first :)

Fixes: https://github.com/crc-org/snc/issues/700