### PR TITLE
CI: Run podman bundle with crc

### DIFF
--- a/ci.sh
+++ b/ci.sh
@@ -5,6 +5,18 @@ set -exuo pipefail
 ./shellcheck.sh
 ./snc.sh
 ./createdisk.sh crc-tmp-install-data
+
+git clone https://github.com/code-ready/crc.git
+pushd crc
+make cross
+sudo mv out/linux-amd64/crc /usr/local/bin/
+popd
+
+crc config set bundle crc_podman_libvirt_*.crcbundle
+crc config set preset podman
+crc setup
+crc start
+
 rc=$?
 echo "${rc}" > /tmp/test-return
 set -e


### PR DESCRIPTION
This PR make sure we run the podman bundles which is created
by CI using crc. It will make sure produced bundles are able to
run without any issue.