### PR TITLE
Microshift: Add growpart package to image builder blueprint

### DIFF
--- a/microshift.sh
+++ b/microshift.sh
@@ -87,6 +87,9 @@ function create_iso {
 [[packages]]
 name = "microshift-release-info"
 version = "*"
+[[packages]]
+name = "cloud-utils-growpart"
+version = "*"
 EOF
     sed -i 's/redhat/core/g' scripts/image-builder/config/kickstart.ks.template
     sed -i "/--bootproto=dhcp/a\network --hostname=api.${SNC_PRODUCT_NAME}.${BASE_DOMAIN}" scripts/image-builder/config/kickstart.ks.template


### PR DESCRIPTION
By default `cloud-utils-growpart` package is not installed which provides `growpart` cli tool to resize the disk image. This pr add that package to image builder blueprint to have it part of generated bundle.