### PR TITLE
Revert "podman: Fix extraction of podman 4.4.2 binary"

### DIFF
--- a/createdisk-library.sh
+++ b/createdisk-library.sh
@@ -353,8 +353,9 @@ function download_podman() {
     local arch=$2
 
     mkdir -p podman-remote/linux
-    curl -L https://github.com/containers/podman/releases/download/v${version}/podman-remote-static-linux_${arch}.tar.gz | tar -zx -C podman-remote/linux podman-remote-static-linux_${arch}
-    mv podman-remote/linux/podman-remote-static-linux_${arch} podman-remote/linux/podman-remote
+    curl -L https://github.com/containers/podman/releases/download/v${version}/podman-remote-static-linux_${arch}.tar.gz | tar -zx -C podman-remote/linux ./bin/podman-remote-static-linux_${arch}
+    mv podman-remote/linux/bin/podman-remote-static-linux_${arch} podman-remote/linux/podman-remote
+    rm -fr podman-remote/linux/bin
     chmod +x podman-remote/linux/podman-remote
 
     if [ -n "${SNC_GENERATE_MACOS_BUNDLE}" ]; then


### PR DESCRIPTION
This reverts commit 4ccff2c48cec40217cfbc082af05b2f865402cec.

fixes #707 they are going to have the dir structure always containing the podman binary inside a bin/ dir