### PR TITLE
Issue 711 - macos: Install older kernel

### DIFF
--- a/createdisk-library.sh
+++ b/createdisk-library.sh
@@ -208,7 +208,7 @@ function install_additional_packages() {
 }
 
 # This is only needed for creating arm64 bundles until RHCOS switches to RHEL-9
-function install_rhel9_kernel {
+function downgrade_rhel9_kernel {
     local vm_ip=$1
     local pkgDir=$(mktemp -d tmp-rpmXXX)
 


### PR DESCRIPTION
Because of https://github.com/crc-org/vfkit/issues/11 we need to use an older kernel with our macOS bundles.
This is fixed in macOS 13, but we want to keep compatibility with macOS 12 for a while.
This uses the kernel which is part of RHEL-9.0 by replacing 9.2 kernel.