### PR TITLE
downgrade_kernel: Use --remove=PKG option of rpm-ostree replace command

### DIFF
--- a/createdisk-library.sh
+++ b/createdisk-library.sh
@@ -197,11 +197,10 @@ function downgrade_kernel() {
     ${SSH} core@${vm_ip} 'sudo bash -x -s' <<EOF
         sed -i -z s/enabled=0/enabled=1/ /etc/yum.repos.d/fedora.repo
         sed -i -z s/enabled=0/enabled=1/ /etc/yum.repos.d/fedora-updates.repo
-        rpm-ostree override replace "${bodhi_url}"
 	# kernel-modules-core is new in kernel 6.x packages and does not exist
 	# in 5.x kernel packages. It will stay around if we don't explicitly
 	# remove it
-        rpm-ostree override remove kernel-modules-core
+        rpm-ostree override replace --remove=kernel-modules-core "${bodhi_url}"
         sed -i -z s/enabled=1/enabled=0/ /etc/yum.repos.d/fedora.repo
         sed -i -z s/enabled=1/enabled=0/ /etc/yum.repos.d/fedora-updates.repo
 EOF


### PR DESCRIPTION
It will make sure in single command unwanted package is removed and required packages are replaced.
```
$ rpm-ostree override replace -h
Usage:
  rpm-ostree override replace [OPTION…] PACKAGE [PACKAGE...]

Replace packages in the base layer

Help Options:
  -h, --help            Show help options

Application Options:
  --remove=PKG          Remove a package
[...]
```