### PR TITLE
Add extra package microshift

### DIFF
--- a/microshift.sh
+++ b/microshift.sh
@@ -54,10 +54,12 @@ ssh-keygen -t ecdsa -b 521 -N "" -f id_ecdsa_crc -C "core"
 # podman package is required to run the ostree-container to serve the rpm-ostree content
 # createrepo package is required to create localrepo for microshift and it's dependenices
 # yum-utils package is required for reposync utility to synchronize packages of a remote DNF repository to a local directory
+# containernetworking-plugins contains networking plugin like bridge which required by podman
+# runc package provide OCI spec for running containers
 function configure_host {
     sudo dnf install -y git osbuild-composer composer-cli ostree rpm-ostree \
       cockpit-composer cockpit-machines bash-completion lorax podman \
-      yum-utils createrepo
+      yum-utils createrepo runc containernetworking-plugins
     sudo systemctl start osbuild-composer.socket
     sudo systemctl start cockpit.socket
     sudo firewall-cmd --add-service=cockpit

--- a/microshift.sh
+++ b/microshift.sh
@@ -120,7 +120,7 @@ sudo cp -Z microshift/_output/image-builder/microshift-installer-*.iso /var/lib/
 OPENSHIFT_RELEASE_VERSION=$(rpm -qp  --qf '%{VERSION}' ${microshift_pkg_dir}/microshift-4.*.rpm)
 # Change 4.x.0~ec0 to 4.x.0-ec0
 # https://docs.fedoraproject.org/en-US/packaging-guidelines/Versioning/#_complex_versioning
-OPENSHIFT_RELEASE_VERSION=$(echo OPENSHIFT_RELEASE_VERSION | tr '~' '-')
+OPENSHIFT_RELEASE_VERSION=$(echo ${OPENSHIFT_RELEASE_VERSION} | tr '~' '-')
 rm -fr ${microshift_pkg_dir}
 
 # Download the oc binary for specific OS environment


### PR DESCRIPTION
These package are required otherwise in the CI (fresh RHEL-9.2) following error occur
```
$ scripts/image-builder/cleanup.sh -full
Error: default OCI runtime "runc" not found: invalid argument

$ scripts/image-builder/build.sh -microshift_rpms /tmp/tmp-rpmIz8 -pull_secret_file /var/lib/jenkins/workspace/eng-crc-microshift/pullsecret.json -lvm_sysroot_size 15360 -authorized_keys_file /var/lib/jenkins/workspace/eng-crc-microshift/id_ecdsa_crc.pub
[...]
time="2023-05-24T08:24:43-04:00" level=warning msg="Failed to load cached network config: network podman not found in CNI cache, falling back to loading network podman from disk"
time="2023-05-24T08:24:43-04:00" level=warning msg="1 error occurred:\n\t* plugin type=\"tuning\" failed (delete): failed to find plugin \"tuning\" in path [/usr/local/libexec/cni /usr/libexec/cni /usr/local/lib/cni /usr/lib/cni /opt/cni/bin]\n\n"
Error: plugin type="bridge" failed (add): failed to find plugin "bridge" in path [/usr/local/libexec/cni /usr/libexec/cni /usr/local/lib/cni /usr/lib/cni /opt/cni/bin]
```