### PR TITLE
microshift: Install weak deps when installing podman

### DIFF
--- a/microshift.sh
+++ b/microshift.sh
@@ -54,12 +54,11 @@ ssh-keygen -t ecdsa -b 521 -N "" -f id_ecdsa_crc -C "core"
 # podman package is required to run the ostree-container to serve the rpm-ostree content
 # createrepo package is required to create localrepo for microshift and it's dependenices
 # yum-utils package is required for reposync utility to synchronize packages of a remote DNF repository to a local directory
-# containernetworking-plugins contains networking plugin like bridge which required by podman
-# runc package provide OCI spec for running containers
 function configure_host {
     sudo dnf install -y git osbuild-composer composer-cli ostree rpm-ostree \
-      cockpit-composer cockpit-machines bash-completion lorax podman \
-      yum-utils createrepo runc containernetworking-plugins
+      cockpit-composer cockpit-machines bash-completion lorax \
+      yum-utils createrepo
+    sudo dnf install -y podman --setopt=install_weak_deps=True
     sudo systemctl start osbuild-composer.socket
     sudo systemctl start cockpit.socket
     sudo firewall-cmd --add-service=cockpit
@@ -107,8 +106,9 @@ EOF
     popd
 }
 
-enable_repos
 configure_host
+
+enable_repos
 microshift_pkg_dir=$(mktemp -p /tmp -d tmp-rpmXXX)
 # This directory contains the microshift rpm  passed to osbuilder, worker for osbuilder
 # running as non-priviledged user and this tmp directory have 0700 permission. To allow


### PR DESCRIPTION
podman requires a container runtime, and networking plugins to work.
They are only marked as Recommends/Suggests in podman's spec file, so we
need to ensure they get installed.
commit 14fdeea installs these explicitly, but podman's spec file
recommends `crun` and not `runc`, no idea if these are the same or not.
Better to rely on what podman .spec file provides rather than hardcoding
it.