### PR TITLE
createdisk: Don't downgrade kernel in case of OKD bundle

### DIFF
--- a/createdisk.sh
+++ b/createdisk.sh
@@ -133,9 +133,11 @@ cleanup_vm_image ${VM_NAME} ${VM_IP}
 
 # Only used for macOS bundle generation
 if [ -n "${SNC_GENERATE_MACOS_BUNDLE}" ]; then
-    # workaround https://github.com/crc-org/vfkit/issues/11 on macOS 12
-    downgrade_rhel9_kernel ${VM_IP}
-    cleanup_vm_image ${VM_NAME} ${VM_IP}
+    if [ ${BUNDLE_TYPE} != "okd" ]; then
+        # workaround https://github.com/crc-org/vfkit/issues/11 on macOS 12
+        downgrade_rhel9_kernel ${VM_IP}
+        cleanup_vm_image ${VM_NAME} ${VM_IP}
+    fi 
 
     # Get the rhcos ostree Hash ID
     ostree_hash=$(${SSH} core@${VM_IP} -- "cat /proc/cmdline | grep -oP \"(?<=${BASE_OS}-).*(?=/vmlinuz)\"")


### PR DESCRIPTION
We added regression 68c6383de78d658b2581fb0f5097dbf34618befc for OKD bundle since we never downgrade kernel for OKD even in case of 4.12 side and OKD always used fedora as base.

During internal discussion we are not sure how many folks are consuming OKD on mac since there is no arm64 support and no bug/issue reported for OKD on mac due to https://github.com/crc-org/vfkit/issues/11.

With this PR we are still not downgrading kernel and if there is some user issue/feedback we will ask community to put a patch for it given that we already have logic in `podman` branch.