### PR TITLE
Add internalIP as node IP for kubelet drop-in unit for OKD bundle

### DIFF
--- a/createdisk.sh
+++ b/createdisk.sh
@@ -113,7 +113,7 @@ cat crio-wipe.service | ${SSH} core@${VM_IP} "sudo tee -a /etc/systemd/system/cr
 # Preload routes controller
 ${SSH} core@${VM_IP} -- "sudo podman pull quay.io/crcont/routes-controller:${image_tag}"
 
-if [ ${BUNDLE_TYPE} == "snc" ]; then
+if [ ${BUNDLE_TYPE} != "microshift" ]; then
     # Add internalIP as node IP for kubelet systemd unit file
     # More details at https://bugzilla.redhat.com/show_bug.cgi?id=1872632
     ${SSH} core@${VM_IP} 'sudo bash -x -s' <<EOF


### PR DESCRIPTION
As of now internalP is part of kubelet drop-in unit file for OCP bundle only but it should be same for OKD also. During d90d53d22d51fdf406e265ac964206f46d2badd0 looks like it added the regression.