### PR TITLE
Add route controller resource to bundle

### DIFF
--- a/createdisk.sh
+++ b/createdisk.sh
@@ -116,6 +116,9 @@ cat crio-wipe.service | ${SSH} core@${VM_IP} "sudo tee -a /etc/systemd/system/cr
 
 # Preload routes controller
 ${SSH} core@${VM_IP} -- "sudo podman pull quay.io/crcont/routes-controller:${image_tag}"
+TAG=${image_tag} envsubst < route_controller.yaml.in > $INSTALL_DIR/route_controller.yaml
+${SCP} $INSTALL_DIR/route_controller.yaml core@${VM_IP}:/home/core/
+${SSH} core@${VM_IP} -- 'sudo mkdir -p /opt/crc && sudo mv /home/core/route_controller.yaml /opt/crc/'
 
 if [ ${BUNDLE_TYPE} != "microshift" ]; then
     # Add internalIP as node IP for kubelet systemd unit file

--- a/route_controller.yaml.in
+++ b/route_controller.yaml.in
@@ -1,0 +1,22 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: routes-controller
+  name: routes-controller
+  namespace: openshift-ingress
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: routes-controller
+  template:
+    metadata:
+      labels:
+        app: routes-controller
+    spec:
+      containers:
+      - image: quay.io/crcont/routes-controller:${TAG}
+        name: routes-controller
+        imagePullPolicy: IfNotPresent
+


### PR DESCRIPTION
This PR adds deployment resource for route controller which use correct image tag, what we cached. Once the bundle is created using this PR, we will also need to make change on crc side. The resource file is located in `/opt` dir same as `kubeconfig` file.