### PR TITLE
Remove lvm system device file

### DIFF
--- a/createdisk.sh
+++ b/createdisk.sh
@@ -81,6 +81,10 @@ EOF
     # Copy the sample microshift config and update the base domain with crc base domain
     ${SSH} core@${VM_IP} -- sudo cp /etc/microshift/config.yaml.default /etc/microshift/config.yaml
     ${SSH} core@${VM_IP} -- "sudo sed -i 's/#baseDomain: .*/baseDomain: ${SNC_PRODUCT_NAME}.${BASE_DOMAIN}/g' /etc/microshift/config.yaml"
+    # Remove the lvm system.device file since it have diskID and deviceName which changes
+    # for different hypervisor and as per `man lvmdevices` if the file does not exist, or if lvm.conf
+    # includes use_devicesfile=0, then lvm will not use a devices file.
+    ${SSH} core@${VM_IP} -- "sudo rm -fr /etc/lvm/devices/system.devices"
 fi
 
 remove_pull_secret_from_disk


### PR DESCRIPTION
As of now this file contain the device name and disk ID associated with a physical volume identifier (PVI) and we noticed that device name is different for different hypervisor like for hyperV it is `/dev/sda` and for libvirt it is `/dev/vda` [0].

In this PR we follow `man lvmdevices` which states remove of this file means lvm will not use a devices file.
```
The  LVM  devices file lists devices that lvm can use.
The default file is /etc/lvm/devices/system.devices, and
the lvmdevices(8) command is used to add or remove device
entries.  If the file does not exist, or if lvm.conf includes
use_devicesfile=0, then lvm will not use a devices file.
```

With this patch I don't see any degrade in boot time
```
<=== with the patch ===>
INFO CRC instance is running with IP 127.0.0.1
INFO CRC VM is running
^C
real	0m13.727s
user	0m0.142s

<=== without the patch ===>
INFO CRC instance is running with IP 127.0.0.1
INFO CRC VM is running
INFO Updating authorized keys...
^C

real	0m14.216s
user	0m0.158s

```

[0] https://www.baeldung.com/linux/vda-vs-sda