### PR TITLE
Downgrade kernel only for mac

### DIFF
--- a/createdisk-library.sh
+++ b/createdisk-library.sh
@@ -112,6 +112,20 @@ function create_qemu_image {
     rm -fr ${destDir}/${base}
 }
 
+function create_bundle_qemu_image() {
+  local libvirtDestDir="$1"
+  local VM_PREFIX="$2"
+  local VM_NAME="$3"
+
+  if [ "${BUNDLE_TYPE}" != "microshift" ]; then
+    create_qemu_image "$libvirtDestDir" "${VM_PREFIX}-base" "${VM_NAME}"
+    mv "${libvirtDestDir}/${VM_NAME}" "${libvirtDestDir}/${SNC_PRODUCT_NAME}.qcow2"
+  else
+    create_qemu_image "$libvirtDestDir" "${VM_NAME}.qcow2" "microshift.qcow2"
+    mv "${libvirtDestDir}/microshift.qcow2" "${libvirtDestDir}/${SNC_PRODUCT_NAME}.qcow2"
+  fi
+}
+
 function update_json_description {
     local srcDir=$1
     local destDir=$2
@@ -431,3 +445,4 @@ function remove_pull_secret_from_disk() {
 	;;
     esac
 }
+

--- a/createdisk.sh
+++ b/createdisk.sh
@@ -181,13 +181,7 @@ libvirtDestDir="${destDirPrefix}_libvirt_${destDirSuffix}"
 rm -fr ${libvirtDestDir} ${libvirtDestDir}.crcbundle
 mkdir "$libvirtDestDir"
 
-if [ $BUNDLE_TYPE != "microshift" ]; then
-    create_qemu_image "$libvirtDestDir" "${VM_PREFIX}-base" "${VM_NAME}"
-    mv "${libvirtDestDir}/${VM_NAME}" "${libvirtDestDir}/${SNC_PRODUCT_NAME}.qcow2"
-else
-    create_qemu_image "$libvirtDestDir" "${VM_NAME}.qcow2" "microshift"
-    mv "${libvirtDestDir}/microshift" "${libvirtDestDir}/${SNC_PRODUCT_NAME}.qcow2"
-fi
+create_bundle_qemu_image "$libvirtDestDir" "${VM_PREFIX}" "${VM_NAME}"
 copy_additional_files "$INSTALL_DIR" "$libvirtDestDir" "${VM_NAME}"
 if [ "${SNC_GENERATE_LINUX_BUNDLE}" != "0" ]; then
     create_tarball "$libvirtDestDir"


### PR DESCRIPTION
68c6383 moved the kernel changes from an aarch64-only block to a block which is run when the macOS bundle is enabled. However, the kernel downgrade is done before any bundle is generated, so the kernel will be downgraded for all our bundles, linux, macos, windows.

This PR fixes this and use https://github.com/crc-org/snc/pull/637 logic to only downgrade the kernel for macOS.