### PR TITLE
Createdisk: update sparsify helper to use for microshift bundle also

### DIFF
--- a/createdisk.sh
+++ b/createdisk.sh
@@ -185,7 +185,8 @@ if [ $BUNDLE_TYPE != "microshift" ]; then
     create_qemu_image "$libvirtDestDir" "${VM_PREFIX}-base" "${VM_NAME}"
     mv "${libvirtDestDir}/${VM_NAME}" "${libvirtDestDir}/${SNC_PRODUCT_NAME}.qcow2"
 else
-    sparsify_lvm "${libvirtDestDir}"
+    create_qemu_image "$libvirtDestDir" "${VM_NAME}.qcow2" "microshift"
+    mv "${libvirtDestDir}/microshift" "${libvirtDestDir}/${SNC_PRODUCT_NAME}.qcow2"
 fi
 copy_additional_files "$INSTALL_DIR" "$libvirtDestDir" "${VM_NAME}"
 if [ "${SNC_GENERATE_LINUX_BUNDLE}" != "0" ]; then


### PR DESCRIPTION
During microshift bundle creation d90d53d22d51fdf406e265ac964206f46d2badd0 we created `sparsify_lvm` to move fast to have microshift bundle sooner. With this PR we are going to use sparsify helper for microshift bundle and remove the `sparsify_lvm` helper.