### PR TITLE
ci_microshift: Remove crc domain after bundle creation

### DIFF
--- a/ci_microshift.sh
+++ b/ci_microshift.sh
@@ -12,6 +12,11 @@ sudo yum install -y make golang
 export CRC_ZSTD_EXTRA_FLAGS="-10"
 ./createdisk.sh crc-tmp-install-data
 
+# Delete the crc domain which created by snc so it can created
+# for crc test
+sudo virsh destroy crc
+sudo virsh undefine crc
+
 git clone https://github.com/crc-org/crc.git
 pushd crc
 make cross


### PR DESCRIPTION
We need to remove the crc domain which is created as part of bundle creation process otherwise we are not able to test the this bundle with `crc` binary which also want to create same domain and fails with following error
```
 level=info msg="Creating CRC VM for MicroShift 4.13.4..."
Error creating machine: Error in driver during machine creation: virError(Code=9, Domain=20, Message='operation failed: domain 'crc' already exists with uuid 5ab0edb0-4c93-484f-8563-a91529d467ba')
```