### PR TITLE
ci_microshift: Just undefine the crc domain

### DIFF
--- a/ci_microshift.sh
+++ b/ci_microshift.sh
@@ -14,7 +14,6 @@ export CRC_ZSTD_EXTRA_FLAGS="-10"
 
 # Delete the crc domain which created by snc so it can created
 # for crc test
-sudo virsh destroy crc
 sudo virsh undefine crc
 
 git clone https://github.com/crc-org/crc.git


### PR DESCRIPTION
During creation of bundle `crc` vm is already in shutdown state so `virsh destroy` commands fails. We only need to undefine the VM.