### PR TITLE
[release-4.14]Install-config: Add MachineAPI to enable as part of capability

### DIFF
--- a/install-config.yaml
+++ b/install-config.yaml
@@ -37,4 +37,5 @@ capabilities:
   - openshift-samples
   - marketplace
   - Console
+  - MachineAPI
 publish: External


### PR DESCRIPTION
From 4.14 MachineAPI is part of capability and we need to explict enabled it.

- https://pkg.go.dev/github.com/openshift/api/config/v1#ClusterVersionCapability