### PR TITLE
Wait till machine config pool is in updated state

### DIFF
--- a/snc.sh
+++ b/snc.sh
@@ -257,4 +257,8 @@ retry ${OC} delete pod --field-selector=status.phase==Succeeded --all-namespaces
 mc_name=$(retry ${OC} get mc --sort-by=.metadata.creationTimestamp --no-headers -oname)
 echo "${mc_name}" | grep rendered-master | head -n -1 | xargs -t ${OC} delete
 echo "${mc_name}" | grep rendered-worker | head -n -1 | xargs -t ${OC} delete
+# Wait till machine config pool is updated correctly
+while retry ${OC} get mcp master -ojsonpath='{.status.conditions[?(@.type!="Updated")].status}' | grep True; do
+    echo "Machine config still in updating/degrading state"
+done
 


### PR DESCRIPTION
Recently we found out that due to mcp is not in updated state, created bundles had issue with machine config like following
```
Marking Degraded due to: machineconfig.machineconfiguration.openshift.io "rendered-master-5e0b4b6fd5ad9c5c64801e18039b9233" not found
```

when the mcp is not updated properly
```
$ oc get mcp
NAME     CONFIG                                             UPDATED   UPDATING   DEGRADED   MACHINECOUNT   READYMACHINECOUNT   UPDATEDMACHINECOUNT   DEGRADEDMACHINECOUNT   AGE
master   rendered-master-5e0b4b6fd5ad9c5c64801e18039b9233   False     True       True       1              0                   0                     1                      3d13h
worker   rendered-worker-e6687df4c217440327c4dc1dcf0f507c   True      False      False      0              0                   0                     0                      3d13h
```