### PR TITLE
gen-bundle-image: refactor to accomodate microshift preset

### DIFF
--- a/gen-bundle-image.sh
+++ b/gen-bundle-image.sh
@@ -57,7 +57,7 @@ function generate_manifest {
    local preset=$2
    podman manifest rm ${preset}-bundle:${version} || true
    podman manifest create ${preset}-bundle:${version}
-   if [[ ${preset} = "podman" ]]; then
+   if [[ ${preset} != "okd" ]]; then
       podman manifest add ${preset}-bundle:${version} containers-storage:localhost/${preset}-bundle:darwin-arm64
    fi
    podman manifest add ${preset}-bundle:${version} containers-storage:localhost/${preset}-bundle:darwin-amd64
@@ -69,7 +69,7 @@ function generate_manifest {
 function sign_bundle_files {
   local preset=$1
   rm -fr *.sig
-  if [[ ${preset} = "podman" ]]; then
+  if [[ ${preset} != "okd" ]]; then
      gpg --batch --default-key crc@crc.dev --pinentry-mode=loopback --passphrase-file ${GPG_SECRET_KEY_PASSPHRASE_PATH} --armor --output ${vfkit_bundle_arm64}.sig --detach-sig ${vfkit_bundle_arm64}
   fi
   gpg --batch --default-key crc@crc.dev --pinentry-mode=loopback --passphrase-file ${GPG_SECRET_KEY_PASSPHRASE_PATH} --armor --output ${vfkit_bundle}.sig --detach-sig ${vfkit_bundle}

--- a/gen-bundle-image.sh
+++ b/gen-bundle-image.sh
@@ -8,22 +8,18 @@ function set_bundle_variables {
    local version=$1
    local preset=$2
 
-   if [[ ${preset} = "openshift" ]]; then
-       vfkit_bundle_arm64=crc_vfkit_${version}_arm64.crcbundle
-   fi
-   if [[ ${preset} = "podman" ]]; then
-       vfkit_bundle_arm64=crc_podman_vfkit_${version}_arm64.crcbundle
+   local bundlePreset=""
+   if [ ${preset} != 'openshift' ]; then
+       bundlePreset="_${preset}"
    fi
 
-   if [[ ${preset} = "openshift" ]]; then
-       preset=""
-   else
-       preset="_${preset}"
+   if [ ${PRESET} != 'okd' ]; then
+       vfkit_bundle_arm64=crc${bundlePreset}_vfkit_${version}_arm64.crcbundle
    fi
 
-   vfkit_bundle=crc${preset}_vfkit_${version}_amd64.crcbundle
-   libvirt_bundle=crc${preset}_libvirt_${version}_amd64.crcbundle
-   hyperv_bundle=crc${preset}_hyperv_${version}_amd64.crcbundle
+   vfkit_bundle=crc${bundlePreset}_vfkit_${version}_amd64.crcbundle
+   libvirt_bundle=crc${bundlePreset}_libvirt_${version}_amd64.crcbundle
+   hyperv_bundle=crc${bundlePreset}_hyperv_${version}_amd64.crcbundle
 }
 
 function generate_image {
@@ -78,7 +74,7 @@ function sign_bundle_files {
 }
 
 if [[ $# -ne 2 ]]; then
-   echo "You need to provide the bundle version and preset (openshift/podman/okd)"
+   echo "You need to provide the bundle version and preset (openshift/podman/okd/microshift)"
    exit 1
 fi
 


### PR DESCRIPTION
This PR refactor around set_bundle_variables, generate_image and sign_bundle_files functions to make sure image can be generated for microshift bundle also.