### PR TITLE
Use GPT partition table instead msdos

### DIFF
--- a/ci_microshift.sh
+++ b/ci_microshift.sh
@@ -14,7 +14,7 @@ export CRC_ZSTD_EXTRA_FLAGS="-10"
 
 # Delete the crc domain which created by snc so it can created
 # for crc test
-sudo virsh undefine crc
+sudo virsh undefine crc --nvram
 
 git clone https://github.com/crc-org/crc.git
 pushd crc

--- a/microshift.sh
+++ b/microshift.sh
@@ -103,6 +103,7 @@ EOF
     sed -i "/--bootproto=dhcp/a\network --hostname=api.${SNC_PRODUCT_NAME}.${BASE_DOMAIN}" scripts/image-builder/config/kickstart.ks.template
     sed -i 's/clearpart --all --initlabel/clearpart --all --disklabel gpt/g' scripts/image-builder/config/kickstart.ks.template
     sed -i "/clearpart --all/a\part biosboot --fstype=biosboot --size=1" scripts/image-builder/config/kickstart.ks.template
+    sed -i '$i\grub2-install --target=i386-pc /dev/vda' scripts/image-builder/config/kickstart.ks.template
     sed -i '$e cat podman_changes.ks' scripts/image-builder/config/kickstart.ks.template
     scripts/image-builder/cleanup.sh -full
     # The home dir and files must have read permissions to group

--- a/microshift.sh
+++ b/microshift.sh
@@ -158,4 +158,5 @@ sudo virt-install \
     --cdrom /var/lib/libvirt/images/microshift-installer.iso \
     --events on_reboot=restart \
     --autoconsole none \
+    --boot uefi \
     --wait 5

--- a/microshift.sh
+++ b/microshift.sh
@@ -101,6 +101,8 @@ version = "*"
 EOF
     sed -i 's/redhat/core/g' scripts/image-builder/config/kickstart.ks.template
     sed -i "/--bootproto=dhcp/a\network --hostname=api.${SNC_PRODUCT_NAME}.${BASE_DOMAIN}" scripts/image-builder/config/kickstart.ks.template
+    sed -i 's/clearpart --all --initlabel/clearpart --all --disklabel gpt/g' scripts/image-builder/config/kickstart.ks.template
+    sed -i "/clearpart --all/a\part biosboot --fstype=biosboot --size=1" scripts/image-builder/config/kickstart.ks.template
     sed -i '$e cat podman_changes.ks' scripts/image-builder/config/kickstart.ks.template
     scripts/image-builder/cleanup.sh -full
     # The home dir and files must have read permissions to group


### PR DESCRIPTION
This PR adds `clearpart` option `--disklabel` to use `gpt` as default disk label and to allow this we also need to add a partition of `biosboot` so that it will not error out with following error.
```
your bios-based system needs a special partition to boot from a gpt disk label
```

- https://pykickstart.readthedocs.io/en/latest/kickstart-docs.html#clearpart
- https://access.redhat.com/solutions/3370891