### PR TITLE
build-patched-kao-kcmo-images.sh: Use https instead of git for encryption

### DIFF
--- a/build-patched-kao-kcmo-images.sh
+++ b/build-patched-kao-kcmo-images.sh
@@ -91,7 +91,7 @@ function patch_and_push_image() {
     if ! brew buildinfo crc-${image_name}-container-${version}-${release}; then
         rhpkg clone containers/crc-${image_name}
         pushd crc-${image_name}
-        git remote add upstream git://pkgs.devel.redhat.com/containers/ose-${image_name}
+        git remote add upstream https://pkgs.devel.redhat.com/git/containers/ose-${image_name}
         # Just fetch the upstream/rhaos-${OCP_VERSION}-rhel-8 instead of all the branches and tags from upstream
         git fetch upstream rhaos-${OCP_VERSION}-rhel-8 --no-tags
         git checkout --track origin/rhaos-${OCP_VERSION}-rhel-8


### PR DESCRIPTION
Looks like internally [0] anonymous operations are changed from `git` to `https` because git protocol miss encryption.

[0] https://issues.redhat.com/browse/RHELBLD-10855

should fix
```
git remote add upstream git://pkgs.devel.redhat.com/containers/ose-cluster-kube-apiserver-operator
+ git fetch upstream rhaos-4.14-rhel-8 --no-tags
fatal: unable to connect to pkgs.devel.redhat.com:
pkgs.devel.redhat.com[0: x.x.x.x]: errno=No route to host
```