### PR TITLE
install-config.yaml: Add image-registry, build and deployment config capability

### DIFF
--- a/install-config.yaml
+++ b/install-config.yaml
@@ -38,4 +38,7 @@ capabilities:
   - marketplace
   - Console
   - MachineAPI
+  - ImageRegistry
+  - DeploymentConfig
+  - Build
 publish: External


### PR DESCRIPTION
4.14 add more capability like image-registry, build and deployment as addon which can be added on top of `None`. By default since we are using `None` those capabilities need to be added explicitly to have it part of cluster since we are providing these features before.