### PR TITLE
Add OperatorLifecycleManager as part of enabled capability

### DIFF
--- a/install-config.yaml
+++ b/install-config.yaml
@@ -41,4 +41,5 @@ capabilities:
   - ImageRegistry
   - DeploymentConfig
   - Build
+  - OperatorLifecycleManager
 publish: External


### PR DESCRIPTION
With 4.15 OperatorLifecycleManager become dependency of marketplace capability. 

This will fix following error
```
failed to create install config: invalid "install-config.yaml" file: additionalEnabledCapabilities: Invalid value: []v1.ClusterVersionCapability{"openshift-samples", "marketplace", "Console", "MachineAPI", "ImageRegistry", "DeploymentConfig", "Build"}: the marketplace capability requires the OperatorLifecycleManager capability
```

- https://pkg.go.dev/github.com/openshift/api/config/v1#ClusterVersionCapabilitySet4_15