### PR TITLE
Revert Change network type to OVNKubernetes from OpenshiftSDN

### DIFF
--- a/install-config.yaml
+++ b/install-config.yaml
@@ -23,7 +23,7 @@ networking:
     hostPrefix: 23
   machineNetwork:
   - cidr: 192.168.126.0/24
-  networkType: OpenShiftSDN
+  networkType: OVNKubernetes
   serviceNetwork:
   - 10.217.4.0/23
 platform:


### PR DESCRIPTION
This reverts commit d18da5d840e8af1597167c795c648d9d5e155b95.

We will try to figure out how much extra resource ovnkubernetes going to consume.