### PR TITLE
Microshift: Add qemu-guest-agent package

### DIFF
--- a/microshift.sh
+++ b/microshift.sh
@@ -98,6 +98,9 @@ version = "*"
 [[packages]]
 name = "cloud-utils-growpart"
 version = "*"
+[[packages]]
+name = "qemu-guest-agent"
+version = "*"
 EOF
     sed -i 's/redhat/core/g' scripts/image-builder/config/kickstart.ks.template
     sed -i "/--bootproto=dhcp/a\network --hostname=api.${SNC_PRODUCT_NAME}.${BASE_DOMAIN}" scripts/image-builder/config/kickstart.ks.template


### PR DESCRIPTION
Time synchronization on macOS relies on qemu guest agent being present, and snc enables a qemu-guest-agent systemd service, which fails to start since the qemu-guest-agent is not installed (more specifically, the unit file created by snc expects /etc/sysconfig/qemu-ga to exist, this is installed by the qemu-guest-agent package)