### PR TITLE
Use latest released rhel-9.0.z kernel

### DIFF
--- a/createdisk-library.sh
+++ b/createdisk-library.sh
@@ -233,10 +233,9 @@ function install_additional_packages() {
 function downgrade_rhel9_kernel {
     local vm_ip=$1
     local pkgDir=$(mktemp -d tmp-rpmXXX)
-    kernel_version=$(sudo dnf --quiet repoquery-na --queryformat '%{version}-%{release}.%{arch}' kernel.${ARCH} | grep el9_0 | tail -n 1)
 
     mkdir -p ${pkgDir}/packages
-    sudo yum download --downloadonly --downloaddir ${pkgDir}/packages kernel-${kernel_version} kernel-modules-extra-${kernel_version} kernel-core-${kernel_version} kernel-modules-${kernel_version} --resolve
+    podman run --rm -v "./${pkgDir}/packages":/packages:z registry.access.redhat.com/ubi9 yum --releasever=9.0 --repo="rhel-9-for-x86_64-baseos-eus-rpms" download --downloaddir /packages kernel kernel-modules-extra kernel-core kernel-modules
     ${SCP} -r ${pkgDir}/packages core@${vm_ip}:/home/core/
     ${SSH} core@${vm_ip} -- 'SYSTEMD_OFFLINE=1 sudo -E rpm-ostree override replace --remove=kernel-modules-core /home/core/packages/*.rpm'
     ${SSH} core@${vm_ip} -- rm -fr /home/core/packages


### PR DESCRIPTION
The kernel we used so far was from October 2022, which is unexpected, we
intended to pick up the latest 9.0.z kernel.

This hardcodes the kernel version to the latest 9.0.z kernel released as
of today, need to find a better way to get this...

This fixes https://github.com/crc-org/snc/issues/826

This also fixes macOS x86_64 microshift bundles which fail to boot
without this. The kernel modules can't be loaded.