### PR TITLE
use arch specific repository id for kernel package

### DIFF
--- a/createdisk-library.sh
+++ b/createdisk-library.sh
@@ -235,7 +235,7 @@ function downgrade_rhel9_kernel {
     local pkgDir=$(mktemp -d tmp-rpmXXX)
 
     mkdir -p ${pkgDir}/packages
-    podman run --rm -v "./${pkgDir}/packages":/packages:z registry.access.redhat.com/ubi9 yum --releasever=9.0 --repo="rhel-9-for-x86_64-baseos-eus-rpms" download --downloaddir /packages kernel kernel-modules-extra kernel-core kernel-modules
+    podman run --rm -v "./${pkgDir}/packages":/packages:z registry.access.redhat.com/ubi9 yum --releasever=9.0 --repo="rhel-9-for-${ARCH}-baseos-eus-rpms" download --downloaddir /packages kernel kernel-modules-extra kernel-core kernel-modules
     ${SCP} -r ${pkgDir}/packages core@${vm_ip}:/home/core/
     ${SSH} core@${vm_ip} -- 'SYSTEMD_OFFLINE=1 sudo -E rpm-ostree override replace --remove=kernel-modules-core /home/core/packages/*.rpm'
     ${SSH} core@${vm_ip} -- rm -fr /home/core/packages


### PR DESCRIPTION
to install the latest rhel-9 kernel we need to use the rhel-9-for-aarch64-baseos-eus-rpms for arm64 and for amd64 the rhel-9-for-x86_64-baseos-eus-rpms repo

this makes use of the ${ARCH} variable to form the repo id