### PR TITLE
Remove crc-dnsmasq container and run dnsmasq directly on vm

### DIFF
--- a/build-patched-kao-kcmo-images.sh
+++ b/build-patched-kao-kcmo-images.sh
@@ -20,7 +20,6 @@ export LANG=C.UTF-8
 
 rm -fr crc-cluster-kube-apiserver-operator
 rm -fr crc-cluster-kube-controller-manager-operator
-rm -fr crc-dnsmasq
 rm -fr crc-routes-controller
 
 readonly OCP_VERSION=4.14
@@ -167,5 +166,4 @@ fi
 
 base_image=$(grep "^FROM openshift/ose-base" crc-cluster-kube-apiserver-operator/Dockerfile | sed 's/^FROM //')
 
-update_base_image crc-dnsmasq "${base_image}"
 update_base_image crc-routes-controller "${base_image}"

--- a/createdisk.sh
+++ b/createdisk.sh
@@ -99,17 +99,14 @@ fi
 prepare_qemu_guest_agent ${VM_IP}
 
 image_tag="latest"
-if podman manifest inspect quay.io/crcont/dnsmasq:${OPENSHIFT_VERSION} >/dev/null 2>&1; then
+if podman manifest inspect quay.io/crcont/routes-controller:${OPENSHIFT_VERSION} >/dev/null 2>&1; then
     image_tag=${OPENSHIFT_VERSION}
 fi
 
-# Add gvisor-tap-vsock and crc-dnsmasq services
+# Add gvisor-tap-vsock service
 ${SSH} core@${VM_IP} 'sudo bash -x -s' <<EOF
   podman create --name=gvisor-tap-vsock --privileged --net=host -v /etc/resolv.conf:/etc/resolv.conf -it quay.io/crcont/gvisor-tap-vsock:latest
   podman generate systemd --restart-policy=no gvisor-tap-vsock > /etc/systemd/system/gvisor-tap-vsock.service
-  touch /var/srv/dnsmasq.conf
-  podman create --ip 10.88.0.8 --name crc-dnsmasq -v /var/srv/dnsmasq.conf:/etc/dnsmasq.conf -p 53:53/udp --privileged quay.io/crcont/dnsmasq:${image_tag}
-  podman generate systemd --restart-policy=no crc-dnsmasq > /etc/systemd/system/crc-dnsmasq.service
   systemctl daemon-reload
   systemctl enable gvisor-tap-vsock.service
 EOF


### PR DESCRIPTION
Right now we use crc-dnsmasq container to provide the dns service for different `.testing` subdomain locally and till now it worked as expected when we were using the openshift-sdn but with OVN-K it is not going to work because this container use new podman bridge and we have fix IP address `10.88.0.8` for it. In case of of OVN-K this IP is not resolvable by dns pod of openshift and dns resolution for those `.testing` subdomain going to fail.

With this removal we need to adjust the code on crc side to put the configuration to VM dnsmasq service and use it.

```
=== using openshift-sdn ===
$ oc rsh busybox-sleep-pod
sh-5.1# ping 10.88.0.8
PING 10.88.0.8 (10.88.0.8) 56(84) bytes of data.
64 bytes from 10.88.0.8: icmp_seq=1 ttl=63 time=0.878 ms
64 bytes from 10.88.0.8: icmp_seq=2 ttl=63 time=0.068 ms

=== using ovn-k ===
sh-5.1# ping 10.88.0.8
PING 10.88.0.8 (10.88.0.8) 56(84) bytes of data.
^C
--- 10.88.0.8 ping statistics ---
15 packets transmitted, 0 received, 100% packet loss, time 14368ms
```