### PR TITLE
Remove hack around MCO .orig file

### DIFF
--- a/createdisk-library.sh
+++ b/createdisk-library.sh
@@ -440,10 +440,6 @@ function remove_pull_secret_from_disk() {
       "microshift")
         ${SSH} core@${VM_IP} -- sudo rm -f /etc/crio/openshift-pull-secret
 	;;
-      "snc")
-	# This assumes there's a single ostree deployment (`ostree admin status`), which is the case at the end of snc.sh
-	${SSH} core@${VM_IP} -- sudo cp /var/lib/kubelet/config.json /etc/machine-config-daemon/orig/var/lib/kubelet/config.json.mcdorig
-	;;
     esac
 }
 


### PR DESCRIPTION
https://issues.redhat.com/browse/OCPBUGS-11437 is now fixed which means we no longer need to use the workaround to update .orig file of pull secret to have it replace with a dummy one.