### PR TITLE
Move OKD bundle from FCOS to SCOS

### DIFF
--- a/createdisk-library.sh
+++ b/createdisk-library.sh
@@ -204,11 +204,9 @@ function install_additional_packages() {
     local vm_ip=$1
     shift
     if [[ ${BASE_OS} = "fedora-coreos" ]]; then
-        ${SSH} core@${vm_ip} -- 'sudo sed -i -z s/enabled=0/enabled=1/ /etc/yum.repos.d/fedora.repo'
-        ${SSH} core@${vm_ip} -- 'sudo sed -i -z s/enabled=0/enabled=1/ /etc/yum.repos.d/fedora-updates.repo'
+        ${SSH} core@${vm_ip} -- 'sudo sed -i -z s/enabled=0/enabled=1/g /etc/yum.repos.d/centos.repo'
         ${SSH} core@${vm_ip} -- "sudo rpm-ostree install --allow-inactive $*"
-        ${SSH} core@${vm_ip} -- 'sudo sed -i -z s/enabled=1/enabled=0/ /etc/yum.repos.d/fedora.repo'
-        ${SSH} core@${vm_ip} -- 'sudo sed -i -z s/enabled=1/enabled=0/ /etc/yum.repos.d/fedora-updates.repo'
+        ${SSH} core@${vm_ip} -- 'sudo sed -i -z s/enabled=1/enabled=0/g /etc/yum.repos.d/centos.repo'
     else
         # Download the hyperV daemons dependency on host
         local pkgDir=$(mktemp -d tmp-rpmXXX)

--- a/createdisk.sh
+++ b/createdisk.sh
@@ -24,6 +24,8 @@ case ${BUNDLE_TYPE} in
         ;;
     okd)
         destDirPrefix="crc_${BUNDLE_TYPE}"
+        # Base OS is not changed for scos-okd because `/proc/cmdline` still contain fedora-coreos
+        # https://github.com/okd-project/okd-scos/issues/18
         BASE_OS=fedora-coreos
         ;;
     snc)

--- a/snc-library.sh
+++ b/snc-library.sh
@@ -39,7 +39,12 @@ function download_oc() {
     fi
     if [ "${SNC_GENERATE_WINDOWS_BUNDLE}" != "0" ]; then
         mkdir -p openshift-clients/windows
-        curl -L "${MIRROR}/${OPENSHIFT_RELEASE_VERSION}/openshift-client-windows-${OPENSHIFT_RELEASE_VERSION}.zip" > openshift-clients/windows/oc.zip
+        if [ "${BUNDLE_TYPE}" == "okd" ]; then
+            # hardcode download url for oc client in windows until it is fixed on scos side
+            curl -L https://github.com/okd-project/okd/releases/download/4.14.0-0.okd-2024-01-06-084517/openshift-client-windows-4.14.0-0.okd-2024-01-06-084517.zip > openshift-clients/windows/oc.zip
+        else
+            curl -L "${MIRROR}/${OPENSHIFT_RELEASE_VERSION}/openshift-client-windows-${OPENSHIFT_RELEASE_VERSION}.zip" > openshift-clients/windows/oc.zip
+        fi
         ${UNZIP} -o -d openshift-clients/windows/ openshift-clients/windows/oc.zip
     fi
 }

--- a/snc.sh
+++ b/snc.sh
@@ -18,7 +18,7 @@ BUNDLE_TYPE="snc"
 if [[ ${OKD_VERSION} != "none" ]]
 then
     OPENSHIFT_VERSION=${OKD_VERSION}
-    MIRROR=${MIRROR:-https://github.com/openshift/okd/releases/download}
+    MIRROR=${MIRROR:-https://github.com/okd-project/okd-scos/releases/download}
     BUNDLE_TYPE="okd"
 fi
 


### PR DESCRIPTION
Since `okd-scos` is better upstream for OCP than FCOS one. It also have pre-release version of 4.15 so switching OKD bundles to it.

- https://github.com/okd-project/okd-scos