### PR TITLE
install-config: Add CloudCredential capability to enabled capabilities

### DIFF
--- a/install-config.yaml
+++ b/install-config.yaml
@@ -42,4 +42,5 @@ capabilities:
   - DeploymentConfig
   - Build
   - OperatorLifecycleManager
+  - CloudCredential
 publish: External


### PR DESCRIPTION
From 4.15 CloudCredential is not part of core capability and it should be enabled if the cluster is not provision on baremetal (we are using libvirt provider).

- https://github.com/openshift/api/blob/2054c69227a1/config/v1/types_cluster_version.go#L488-L503

As part of libvirt provider we really don't need it and removing is as part of cvo-override.

This pr will fix following issue as part of snc run.
```
+ ./openshift-baremetal-install --dir crc-tmp-install-data create manifests
level=error msg=failed to fetch Master Machines: failed to load asset "Install Config": failed to create install config: invalid "install-config.yaml" file: capabilities: Invalid value: types.Capabilities{BaselineCapabilitySet:"None", AdditionalEnabledCapabilities:[]v1.ClusterVersionCapability{"openshift-samples", "marketplace", "Console", "MachineAPI", "ImageRegistry", "DeploymentConfig", "Build", "OperatorLifecycleManager"}}: disabling CloudController capability available only for baremetal platforms
```

fixes: #838 