### PR TITLE
Update oc binary download url for arm64 binary

### DIFF
--- a/snc-library.sh
+++ b/snc-library.sh
@@ -35,7 +35,11 @@ function download_oc() {
 
     if [ "${SNC_GENERATE_MACOS_BUNDLE}" != "0" ]; then
         mkdir -p openshift-clients/mac
-        curl -L "${MIRROR}/${OPENSHIFT_RELEASE_VERSION}/openshift-client-mac-${OPENSHIFT_RELEASE_VERSION}.tar.gz" | tar -zx -C openshift-clients/mac oc
+        if [ "${yq_ARCH}" == "arm64" ]; then
+            curl -L "${MIRROR}/${OPENSHIFT_RELEASE_VERSION}/openshift-client-mac-${yq_ARCH}-${OPENSHIFT_RELEASE_VERSION}.tar.gz" | tar -zx -C openshift-clients/mac oc
+        else
+            curl -L "${MIRROR}/${OPENSHIFT_RELEASE_VERSION}/openshift-client-mac-${OPENSHIFT_RELEASE_VERSION}.tar.gz" | tar -zx -C openshift-clients/mac oc
+        fi
     fi
     if [ "${SNC_GENERATE_WINDOWS_BUNDLE}" != "0" ]; then
         mkdir -p openshift-clients/windows


### PR DESCRIPTION
Looks like there is confusion around the oc download path url to grab platfrom specific binary. Ideally if we use arch specific url to download the oc binary it should have by default for that specific org which is not the case so need to explicit specify the arch info in the url.

- https://issues.redhat.com/browse/OCPBUGS-28720