### PR TITLE
Switch Network type from OpenShiftSDN to OVNKubernetes

### DIFF
--- a/install-config.yaml
+++ b/install-config.yaml
@@ -23,7 +23,7 @@ networking:
     hostPrefix: 23
   machineNetwork:
   - cidr: 192.168.126.0/24
-  networkType: OpenShiftSDN
+  networkType: OVNKubernetes
   serviceNetwork:
   - 10.217.4.0/23
 platform:

--- a/snc.sh
+++ b/snc.sh
@@ -31,7 +31,7 @@ BASE_DOMAIN=${CRC_BASE_DOMAIN:-testing}
 CRC_PV_DIR="/mnt/pv-data"
 SSH="ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i id_ecdsa_crc"
 SCP="scp -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i id_ecdsa_crc"
-MIRROR=${MIRROR:-https://mirror.openshift.com/pub/openshift-v4/$ARCH/clients/ocp-dev-preview}
+MIRROR=${MIRROR:-https://mirror.openshift.com/pub/openshift-v4/$ARCH/clients/ocp}
 CERT_ROTATION=${SNC_DISABLE_CERT_ROTATION:-enabled}
 USE_PATCHED_RELEASE_IMAGE=${SNC_USE_PATCHED_RELEASE_IMAGE:-disabled}
 HTPASSWD_FILE='users.htpasswd'


### PR DESCRIPTION
With 4.15, OpenShiftSDN network plugin removed and OVNKubernetes is only option which is supported.

- https://access.redhat.com/documentation/en-us/openshift_container_platform/4.14/html-single/release_notes/index#ocp-4-14-future-deprecation-sdn