### PR TITLE
Change managementState of Image Registry Operator config from Removed to Managed

### DIFF
--- a/snc.sh
+++ b/snc.sh
@@ -201,6 +201,10 @@ retry ${OC} patch clusterversion version --type json -p "$(cat cvo-overrides-aft
 # Scale route deployment from 2 to 1
 retry ${OC} scale --replicas=1 ingresscontroller/default -n openshift-ingress-operator
 
+# Set managementState Image Registry Operator configuration from Removed to Managed
+# because https://docs.openshift.com/container-platform/4.15/registry/configuring_registry_storage/configuring-registry-storage-baremetal.html#registry-removed_configuring-registry-storage-baremetal
+retry ${OC} patch config.imageregistry.operator.openshift.io/cluster --patch '{"spec":{"managementState":"Managed"}}' --type=merge
+
 # Set default route for registry CRD from false to true.
 retry ${OC} patch config.imageregistry.operator.openshift.io/cluster --patch '{"spec":{"defaultRoute":true}}' --type=merge
 


### PR DESCRIPTION
Since we switched from libvirt IPI to SNO where platform is used as
    `none` so the image registry operator bootstraps itself as Removed.
    Which means registry operator not start the registry instance and any
    configurations are ignored. Since registry operator not started that
    means there is no registry route and user not able to push image to
    internal registry and get following error.
    
```
    podman login -u kubeadmin -p $(oc whoami -t) default-route-openshift-image-registry.apps-crc.testing --tls-verify=false` we get an error:
    Error: authenticating creds for "default-route-openshift-image-registry.apps-crc.testing": pinging container registry default-route-openshift-image-registry.apps-crc.testing: received unexpected HTTP status: 503 Service Unavailable
```
    
- https://access.redhat.com/solutions/5114881
- https://docs.openshift.com/container-platform/4.15/registry/configuring_registry_storage/configuring-registry-storage-baremetal.html#registry-removed_configuring-registry-storage-baremetal
   

    fixes: #862
