### PR TITLE
Add kubelet config file to update containerLogMaxSize and containerLogMaxFiles setting

### DIFF
--- a/99-kubelet-log-size-config.yaml
+++ b/99-kubelet-log-size-config.yaml
@@ -1,0 +1,11 @@
+apiVersion: machineconfiguration.openshift.io/v1
+kind: KubeletConfig
+metadata:
+  name: container-logs-limit
+spec:
+  machineConfigPoolSelector:
+    matchLabels:
+      pools.operator.machineconfiguration.openshift.io/master: ""
+  kubeletConfig:
+    containerLogMaxSize: "2Mi"
+    containerLogMaxFiles: "2"

--- a/snc.sh
+++ b/snc.sh
@@ -147,6 +147,8 @@ cp cluster-network-03-config.yaml ${INSTALL_DIR}/manifests/
 cp 99_master-chronyd-mask.yaml $INSTALL_DIR/openshift/
 # Add dummy network unit file
 cp 99-openshift-machineconfig-master-dummy-networks.yaml $INSTALL_DIR/openshift/
+# Add kubelet config to have 5MiB log size instead 50MiB and 2 log files instead 5
+cp 99-kubelet-log-size-config.yaml $INSTALL_DIR/openshift/
 # Add kubelet config resource to make change in kubelet
 DYNAMIC_DATA=$(base64 -w0 node-sizing-enabled.env) envsubst < 99_master-node-sizing-enabled-env.yaml.in > $INSTALL_DIR/openshift/99_master-node-sizing-enabled-env.yaml
 # Add codeReadyContainer as invoker to identify it with telemeter


### PR DESCRIPTION
…gMaxFiles setting

By default log size is set to 50Mi and number of log file is set to 5 but for local developement we might not need those setting where disk space is also critical. In this PR we are changing it to 5Mi and 2 respectivily.

During the testing (generation of 4.15.3 bundle) I can see reduction of ~ 200 MB to final bundle size.