### PR TITLE
4.16: Update Mirror url from `ocp-dev-preview` to `ocp`

### DIFF
--- a/microshift.sh
+++ b/microshift.sh
@@ -15,7 +15,7 @@ SNC_CLUSTER_MEMORY=${SNC_CLUSTER_MEMORY:-2048}
 SNC_CLUSTER_CPUS=${SNC_CLUSTER_CPUS:-2}
 CRC_VM_DISK_SIZE=${CRC_VM_DISK_SIZE:-31}
 BASE_DOMAIN=${CRC_BASE_DOMAIN:-testing}
-MIRROR=${MIRROR:-https://mirror.openshift.com/pub/openshift-v4/$ARCH/clients/ocp-dev-preview}
+MIRROR=${MIRROR:-https://mirror.openshift.com/pub/openshift-v4/$ARCH/clients/ocp}
 OPENSHIFT_MINOR_VERSION=${OPENSHIFT_MINOR_VERSION:-4.16}
 
 if ! grep -q -i "release 9" /etc/redhat-release

--- a/repos/mirror-microshift.repo
+++ b/repos/mirror-microshift.repo
@@ -1,5 +1,5 @@
 [mirror-microshift]
 name=microshift repo for mirror
-baseurl=https://mirror.openshift.com/pub/openshift-v4/$basearch/microshift/ocp-dev-preview/latest-4.16/el9/os/
+baseurl=https://mirror.openshift.com/pub/openshift-v4/$basearch/microshift/ocp/latest-4.16/el9/os/
 enabled=1
 gpgcheck=0

--- a/snc.sh
+++ b/snc.sh
@@ -31,7 +31,7 @@ BASE_DOMAIN=${CRC_BASE_DOMAIN:-testing}
 CRC_PV_DIR="/mnt/pv-data"
 SSH="ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i id_ecdsa_crc"
 SCP="scp -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i id_ecdsa_crc"
-MIRROR=${MIRROR:-https://mirror.openshift.com/pub/openshift-v4/$ARCH/clients/ocp-dev-preview}
+MIRROR=${MIRROR:-https://mirror.openshift.com/pub/openshift-v4/$ARCH/clients/ocp}
 CERT_ROTATION=${SNC_DISABLE_CERT_ROTATION:-enabled}
 USE_PATCHED_RELEASE_IMAGE=${SNC_USE_PATCHED_RELEASE_IMAGE:-disabled}
 HTPASSWD_FILE='users.htpasswd'


### PR DESCRIPTION
4.16 bits now available as release candidate to mirror.openshift.com under `ocp` location instead `ocp-dev-preview`.