### PR TITLE
Remove kernel downgrade logic for vfkit bundles

### DIFF
--- a/createdisk-library.sh
+++ b/createdisk-library.sh
@@ -202,20 +202,6 @@ function install_additional_packages() {
     fi
 }
 
-# This is only needed for creating arm64 bundles until RHCOS switches to RHEL-9
-function downgrade_rhel9_kernel {
-    local vm_ip=$1
-    local pkgDir=$(mktemp -d tmp-rpmXXX)
-    kernel_version=$(sudo dnf --quiet repoquery-na --queryformat '%{version}-%{release}.%{arch}' kernel.${ARCH} | grep el9_0 | tail -n 1)
-
-    mkdir -p ${pkgDir}/packages
-    sudo yum download --downloadonly --downloaddir ${pkgDir}/packages kernel-${kernel_version} kernel-modules-extra-${kernel_version} kernel-core-${kernel_version} kernel-modules-${kernel_version} --resolve
-    ${SCP} -r ${pkgDir}/packages core@${vm_ip}:/home/core/
-    ${SSH} core@${vm_ip} -- 'SYSTEMD_OFFLINE=1 sudo -E rpm-ostree override replace --remove=kernel-modules-core /home/core/packages/*.rpm'
-    ${SSH} core@${vm_ip} -- rm -fr /home/core/packages
-    rm -fr ${pkgDir}
-}
-
 function prepare_cockpit() {
     local vm_ip=$1
 


### PR DESCRIPTION
We already put warning around 3 release before for crc side that macOS < 13 is not supported and try to update the os. With this PR, kernel downgrade logic is removed which is required for macos<13.

Bundle created using this PR will not work for macos less than 13.x.

- https://github.com/crc-org/crc/pull/4029