### PR TITLE
kao-kcmo-images.sh: Add reference for `image_from_brew` variable

### DIFF
--- a/build-patched-kao-kcmo-images.sh
+++ b/build-patched-kao-kcmo-images.sh
@@ -102,7 +102,7 @@ function patch_and_push_image() {
     # Metadata output from pull list offers 2 variants - SHA digest variant and tag variant.
     # They are essentially the same, so we can choose either ([0] or [1]).
     image_from_brew=$(curl -L https://download.eng.bos.redhat.com/brewroot/packages/crc-cluster-kube-apiserver-operator-container/${version}/${release}/metadata.json | jq -r '.build.extra.image.index.pull[0]')
-    skopeo copy --dest-authfile ${OPENSHIFT_PULL_SECRET_PATH} --all --src-cert-dir=pki/ docker://{image_from_brew} docker://quay.io/crcont/openshift-crc-${image_name}:${openshift_version}
+    skopeo copy --dest-authfile ${OPENSHIFT_PULL_SECRET_PATH} --all --src-cert-dir=pki/ docker://${image_from_brew} docker://quay.io/crcont/openshift-crc-${image_name}:${openshift_version}
 }
 
 function create_patched_release_image_for_arch() {


### PR DESCRIPTION
Missed during the review of 4fdb1443d7c24e173497a18198ba20cae202a7d0 one :(