### PR TITLE
[master] Remove kernel downgrade logic for vfkit bundles

### DIFF
--- a/createdisk-library.sh
+++ b/createdisk-library.sh
@@ -200,19 +200,6 @@ function install_additional_packages() {
     fi
 }
 
-# This is only needed for creating arm64 bundles until RHCOS switches to RHEL-9
-function downgrade_rhel9_kernel {
-    local vm_ip=$1
-    local pkgDir=$(mktemp -d tmp-rpmXXX)
-
-    mkdir -p ${pkgDir}/packages
-    podman run --rm -v "./${pkgDir}/packages":/packages:z registry.access.redhat.com/ubi9 yum --releasever=9.0 --repo="rhel-9-for-${ARCH}-baseos-eus-rpms" download --downloaddir /packages kernel kernel-modules-extra kernel-core kernel-modules
-    ${SCP} -r ${pkgDir}/packages core@${vm_ip}:/home/core/
-    ${SSH} core@${vm_ip} -- 'SYSTEMD_OFFLINE=1 sudo -E rpm-ostree override replace --remove=kernel-modules-core /home/core/packages/*.rpm'
-    ${SSH} core@${vm_ip} -- rm -fr /home/core/packages
-    rm -fr ${pkgDir}
-}
-
 function prepare_cockpit() {
     local vm_ip=$1
 

--- a/createdisk.sh
+++ b/createdisk.sh
@@ -134,6 +134,22 @@ cleanup_vm_image ${VM_NAME} ${VM_IP}
 
 podman_version=$(${SSH} core@${VM_IP} -- 'rpm -q --qf %{version} podman')
 
+# Get the rhcos ostree Hash ID
+ostree_hash=$(${SSH} core@${VM_IP} -- "cat /proc/cmdline | grep -oP \"(?<=${BASE_OS}-).*(?=/vmlinuz)\"")
+
+# Get the rhcos kernel release
+kernel_release=$(${SSH} core@${VM_IP} -- 'uname -r')
+
+# Get the kernel command line arguments
+kernel_cmd_line=$(${SSH} core@${VM_IP} -- 'cat /proc/cmdline')
+
+# Get the vmlinux/initramfs to /tmp/kernel and change permission for initramfs
+${SSH} core@${VM_IP} -- "mkdir /tmp/kernel && sudo cp -r /boot/ostree/${BASE_OS}-${ostree_hash}/*${kernel_release}* /tmp/kernel && sudo chmod 644 /tmp/kernel/initramfs*"
+
+# SCP the vmlinuz/initramfs from VM to Host in provided folder.
+${SCP} -r core@${VM_IP}:/tmp/kernel/* $INSTALL_DIR
+${SSH} core@${VM_IP} -- "sudo rm -fr /tmp/kernel"
+
 # Shutdown the VM
 shutdown_vm ${VM_NAME}
 
@@ -168,36 +184,8 @@ fi
 # This must be done after the generation of libvirt image as it reuses some of
 # the content of $libvirtDestDir
 if [ "${SNC_GENERATE_MACOS_BUNDLE}" != "0" ]; then
-    start_vm ${VM_NAME} ${VM_IP}
-    if [ ${BUNDLE_TYPE} != "okd" ]; then
-        # workaround https://github.com/crc-org/vfkit/issues/11 on macOS 12
-        downgrade_rhel9_kernel ${VM_IP}
-        cleanup_vm_image ${VM_NAME} ${VM_IP}
-    fi
-
-    # Get the rhcos ostree Hash ID
-    ostree_hash=$(${SSH} core@${VM_IP} -- "cat /proc/cmdline | grep -oP \"(?<=${BASE_OS}-).*(?=/vmlinuz)\"")
-
-    # Get the rhcos kernel release
-    kernel_release=$(${SSH} core@${VM_IP} -- 'uname -r')
-
-    # Get the kernel command line arguments
-    kernel_cmd_line=$(${SSH} core@${VM_IP} -- 'cat /proc/cmdline')
-
-    # Get the vmlinux/initramfs to /tmp/kernel and change permission for initramfs
-    ${SSH} core@${VM_IP} -- "mkdir /tmp/kernel && sudo cp -r /boot/ostree/${BASE_OS}-${ostree_hash}/*${kernel_release}* /tmp/kernel && sudo chmod 644 /tmp/kernel/initramfs*"
-
-    # SCP the vmlinuz/initramfs from VM to Host in provided folder.
-    ${SCP} -r core@${VM_IP}:/tmp/kernel/* $INSTALL_DIR
-
-    ${SSH} core@${VM_IP} -- "sudo rm -fr /tmp/kernel"
-    shutdown_vm ${VM_NAME}
-
     vfkitDestDir="${destDirPrefix}_vfkit_${destDirSuffix}"
     rm -fr ${vfkitDestDir} ${vfkitDestDir}.crcbundle
-
-    create_qemu_image "$libvirtDestDir"
-
     generate_vfkit_bundle "$libvirtDestDir" "$vfkitDestDir" "$INSTALL_DIR" "$kernel_release" "$kernel_cmd_line"
 
     # Cleanup up vmlinux/initramfs files


### PR DESCRIPTION
We already put warning around 3 release before for crc side that macOS < 13 is not supported and try to update the os. With this PR, kernel downgrade logic is removed which is required for macos<13.

Bundle created using this PR will not work for macos less than 13.x.

- https://github.com/crc-org/crc/pull/4029


Manual cherry-picked because it failed automatic https://github.com/crc-org/snc/pull/890#issuecomment-2133349717