### PR TITLE
[release-4.15] CI: update golang container image to v1.21

### DIFF
--- a/ci.sh
+++ b/ci.sh
@@ -58,7 +58,7 @@ sudo systemctl reload NetworkManager
 
 git clone https://github.com/code-ready/crc.git
 pushd crc
-podman run --rm -v ${PWD}:/data:Z registry.ci.openshift.org/openshift/release:rhel-8-release-golang-1.20-openshift-4.15 /bin/bash -c "cd /data && make cross"
+podman run --rm -v ${PWD}:/data:Z registry.ci.openshift.org/openshift/release:rhel-8-release-golang-1.21-openshift-4.16 /bin/bash -c "cd /data && make cross"
 sudo mv out/linux-amd64/crc /usr/local/bin/
 popd
 

--- a/ci_microshift.sh
+++ b/ci_microshift.sh
@@ -18,7 +18,7 @@ sudo virsh undefine crc --nvram
 
 git clone https://github.com/crc-org/crc.git
 pushd crc
-podman run --rm -v ${PWD}:/data:Z registry.ci.openshift.org/openshift/release:rhel-8-release-golang-1.20-openshift-4.15 /bin/bash -c "cd /data && make cross"
+podman run --rm -v ${PWD}:/data:Z registry.ci.openshift.org/openshift/release:rhel-8-release-golang-1.21-openshift-4.16 /bin/bash -c "cd /data && make cross"
 sudo mv out/linux-amd64/crc /usr/local/bin/
 popd
 


### PR DESCRIPTION
crc codebase now uses go-1.21 and it fails to build with go-1.20 now.

Should fix following error in CI
```
OARCH=arm64 GOOS=darwin go build -tags "containers_image_openpgp" -ldflags="-X github.com/crc-org/crc/v2/pkg/crc/version.crcVersion=2.37.0 -X github.com/crc-org/crc/v2/pkg/crc/version.ocpVersion=4.15.14 -X github.com/crc-org/crc/v2/pkg/crc/version.okdVersion=4.15.0-0.okd-2024-02-23-163410 -X github.com/crc-org/crc/v2/pkg/crc/version.microshiftVersion=4.15.14 -X github.com/crc-org/crc/v2/pkg/crc/version.commitSha=c74697 " -o out/macos-arm64/crc  ./cmd/crc
vendor/github.com/containers/image/v5/pkg/blobinfocache/internal/prioritize/prioritize.go:6:2: package cmp is not in GOROOT (/usr/lib/golang/src/cmp)
note: imported by a module that requires go 1.21
vendor/github.com/containers/image/v5/internal/signature/sigstore.go:6:2: package maps is not in GOROOT (/usr/lib/golang/src/maps)
note: imported by a module that requires go 1.21
vendor/github.com/containers/image/v5/internal/pkg/platform/platform_matcher.go:24:2: package slices is not in GOROOT (/usr/lib/golang/src/slices)
note: imported by a module that requires go 1.21
```