### PR TITLE
Use oc binary which is built on RHEL8

### DIFF
--- a/snc-library.sh
+++ b/snc-library.sh
@@ -31,7 +31,7 @@ function download_oc() {
     fi
 
     mkdir -p openshift-clients/linux
-    curl -L "${MIRROR}/${OPENSHIFT_RELEASE_VERSION}/openshift-client-linux-${OPENSHIFT_RELEASE_VERSION}.tar.gz" | tar -zx -C openshift-clients/linux oc
+    curl -L "${MIRROR}/${OPENSHIFT_RELEASE_VERSION}/openshift-client-linux-${yq_ARCH}-rhel8-${OPENSHIFT_RELEASE_VERSION}.tar.gz" | tar -zx -C openshift-clients/linux oc
 
     if [ "${SNC_GENERATE_MACOS_BUNDLE}" != "0" ]; then
         mkdir -p openshift-clients/mac


### PR DESCRIPTION
looks like the default oc tarball is built on RHEL9 instead RHEL8 and it cause following issue when running it on RHEL-8
```
oc: /lib64/libc.so.6: version `GLIBC_2.33' not found (required by oc)
oc: /lib64/libc.so.6: version `GLIBC_2.34' not found (required by oc)
oc: /lib64/libc.so.6: version `GLIBC_2.32' not found (required by oc)
```

This patch now explicit use the oc tarball which is built on RHEL8

Fixes: #910 