### PR TITLE
Only use qemu-guest-agent on macos

### DIFF
--- a/qemu-guest-agent.service
+++ b/qemu-guest-agent.service
@@ -1,6 +1,7 @@
 [Unit]
 Description=QEMU Guest Agent
 IgnoreOnIsolate=True
+ConditionVirtualization=apple
 
 [Service]
 UMask=0077


### PR DESCRIPTION
On linux/windows, we don't setup the needed vsock devices, so
qemu-guest-agent fails to start.
We can use `ConditionVirtualization=apple` to only start it when running
on a mac.