### PR TITLE
[release-4.16]Revert "build-patched-kao-kcmo-images.sh: get image name from brew container image metadata

### DIFF
--- a/build-patched-kao-kcmo-images.sh
+++ b/build-patched-kao-kcmo-images.sh
@@ -99,10 +99,10 @@ function patch_and_push_image() {
         rhpkg container-build --target crc-1-rhel-9-candidate
         popd
     fi
-    # Metadata output from pull list offers 2 variants - SHA digest variant and tag variant.
-    # They are essentially the same, so we can choose either ([0] or [1]).
-    image_from_brew=$(curl -L https://download.eng.bos.redhat.com/brewroot/packages/crc-${image_name}-container/${version}/${release}/metadata.json | jq -r '.build.extra.image.index.pull[0]')
-    skopeo copy --dest-authfile ${OPENSHIFT_PULL_SECRET_PATH} --all --src-cert-dir=pki/ docker://${image_from_brew} docker://quay.io/crcont/openshift-crc-${image_name}:${openshift_version}
+    # Operator images created using rhel-9 tags have `rhel9-operator` as part of image name so replacing `operator` with it.
+    # https://www.gnu.org/software/bash/manual/bash.html#Shell-Parameter-Expansion
+    rhel9_image_name="${image_name/operator/rhel9-operator}"
+    skopeo copy --dest-authfile ${OPENSHIFT_PULL_SECRET_PATH} --all --src-cert-dir=pki/ docker://registry-proxy.engineering.redhat.com/rh-osbs/openshift-crc-${rhel9_image_name}:${version}-${release} docker://quay.io/crcont/openshift-crc-${image_name}:${openshift_version}
 }
 
 function create_patched_release_image_for_arch() {


### PR DESCRIPTION
This reverts commit a2b6ece823dfade602a128585e477fbdf6ac56ab.

Revert "kao-kcmo-images.sh: Don't hardcode the image name"

This reverts commit d4ca7af70589d951ec19df5363da52b1757ff307.

Revert "kao-kcmo-images.sh: Add reference for `image_from_brew` variable"

This reverts commit 8c64f2d9e24713c615a92f40376d39f4a0ab23cf.

We need to revert since the metadata file is not available for quite some time even after the brew build successful and CI is failing because of that with following error.

```
++ curl -L https://download.eng.bos.redhat.com/brewroot/packages/crc-cluster-kube-apiserver-operator-container/v4.15.0/202406052127.p0.geae6926.assembly.stream.el9/metadata.json
++ jq -r '.build.extra.image.index.pull[0]'
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed

  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
100   328  100   328    0     0   2000      0 --:--:-- --:--:-- --:--:--  2012
parse error: Invalid numeric literal at line 1, column 10
```