### PR TITLE
snc-library: Delete the failed pods before check for available one

### DIFF
--- a/snc-library.sh
+++ b/snc-library.sh
@@ -243,6 +243,7 @@ function no_operators_degraded() {
 
 function all_pods_are_running_completed() {
     local ignoreNamespace=$1
+    ${OC} delete pods --field-selector=status.phase=Failed -A
     ! ${OC} get pod --no-headers --all-namespaces --field-selector=metadata.namespace!="${ignoreNamespace}" | grep -v Running | grep -v Completed
 }
 


### PR DESCRIPTION
Sometime pods goes to `ContainerStatusUnknown` state where it is not able to send the status to kubelet and it stays there till manually deleted and due to it our snc script fails. In this PR we are deleting the pods which are in failed state (which is the same for ContainerStatusUnknown one) and then checks the pods availablity.

```
+ sleep 256
+ all_pods_are_running_completed none
+ local ignoreNamespace=none
+ ./openshift-clients/linux/oc get pod --no-headers --all-namespaces '--field-selector=metadata.namespace!=none'
+ grep -v Running
+ grep -v Completed
openshift-kube-apiserver                           installer-11-crc                                         0/1   ContainerStatusUnknown   1                19m
+ exit=1
+ wait=512
+ count=10
+ '[' 10 -lt 10 ']'
+ echo 'Retry 10/10 exited 1, no more retries left.'
Retry 10/10 exited 1, no more retries left.
```

fixes: #920