### PR TITLE
Microshift: Use  listenAddress value as null for microshift config

### DIFF
--- a/ci_microshift.sh
+++ b/ci_microshift.sh
@@ -5,7 +5,7 @@ set -exuo pipefail
 sudo yum install -y make golang
 
 ./shellcheck.sh
-MICROSHIFT_PRERELEASE=yes ./microshift.sh
+./microshift.sh
 
 # Set the zstd compression level to 10 to have faster
 # compression while keeping a reasonable bundle size.

--- a/createdisk.sh
+++ b/createdisk.sh
@@ -74,6 +74,7 @@ EOF
     ${SSH} core@${VM_IP} -- sudo systemctl disable firewalld
     ${SSH} core@${VM_IP} -- cat /etc/microshift/config.yaml.default > config.yaml
     ${YQ} eval --inplace ".dns.baseDomain = \"${SNC_PRODUCT_NAME}.${BASE_DOMAIN}\""  config.yaml
+    ${YQ} eval --inplace ".ingress.listenAddress = null"  config.yaml
     ${SCP} config.yaml core@${VM_IP}:/home/core
     ${SSH} core@${VM_IP} -- 'sudo mv /home/core/config.yaml /etc/microshift/config.yaml'
     # Make sure `baseDomain` is set to crc.testing


### PR DESCRIPTION
Because of https://issues.redhat.com//browse/OCPBUGS-35468 bug microshift is failed to start and as workaround the value of `listenAddress` should be `null`. It will fix following error

```
Jul 03 04:30:53 api.crc.testing microshift[1933]: ??? I0703 04:30:53.417607    1933 run.go:64] "Version" microshift="4.16.0" base="4.16.0"
Jul 03 04:30:53 api.crc.testing microshift[1933]: ??? E0703 04:30:53.421007    1933 run.go:74] "command failed" err="invalid configuration: error validating ingress.listenAddress: interface  not present in the host
```

Fixes: #928 