### PR TITLE
[release-4.16] Delete pods and lease using etcd container

### DIFF
--- a/createdisk.sh
+++ b/createdisk.sh
@@ -133,6 +133,16 @@ fi
 
 cleanup_vm_image ${VM_NAME} ${VM_IP}
 
+# Delete all the pods and lease from the etcd db so that when this bundle is use for the cluster provision, everything comes up in clean state.
+if [ ${BUNDLE_TYPE} != "microshift" ]; then
+    etcd_image=$(${SSH} core@${VM_IP} -- "sudo jq -r '.spec.containers[] | select(.name == \"etcd\") | .image' /etc/kubernetes/manifests/etcd-pod.yaml")
+    ${SSH} core@${VM_IP} -- "sudo podman run --rm --network=host --privileged --replace --name crc-etcd --detach --entrypoint etcd -v /var/lib/etcd:/store \"${etcd_image}\" --data-dir /store"
+    sleep 5
+    ${SSH} core@${VM_IP} -- "sudo podman exec crc-etcd etcdctl del --prefix /kubernetes.io/pods"
+    ${SSH} core@${VM_IP} -- "sudo podman exec crc-etcd etcdctl del --prefix /kubernetes.io/leases"
+    ${SSH} core@${VM_IP} -- "sudo podman stop crc-etcd"
+fi
+
 podman_version=$(${SSH} core@${VM_IP} -- 'rpm -q --qf %{version} podman')
 
 # Get the rhcos ostree Hash ID


### PR DESCRIPTION
As of now when user consume the bundle to provision the cluster, old data around pods and lease is consumed and timestamp for those pods are also around same time when we first provisioned this cluster. This PR try to use etcd image to run etcd server using same db which created by the cluster  and uses etcdctl command to delete the pods and lease details. It will help to make sure every pods comes up in clean state.

Something similar done in recert project

- https://github.com/openshift-kni/lifecycle-agent/blob/fd1cf27502b9c3f136fa1d161bcbd7ecf7c19da4/lca-cli/ops/ops.go#L186-L221