### PR TITLE
ci.sh: moved test artifacts folder to crc-tmp-install-data

### DIFF
--- a/ci.sh
+++ b/ci.sh
@@ -66,9 +66,9 @@ crc config set bundle crc_libvirt_*.crcbundle
 crc setup
 crc start --disk-size 80 -m 24000 -c 10 -p "${HOME}"/pull-secret
 
-mkdir -p /tmp/artifacts
+mkdir -p crc-tmp-install-data/test-artifacts
 export KUBECONFIG="${HOME}"/.crc/machines/crc/kubeconfig
-openshift-tests run kubernetes/conformance --dry-run | grep -F -v -f /tmp/ignoretests.txt | openshift-tests run -o /tmp/artifacts/e2e.log --junit-dir /tmp/artifacts/junit --disable-monitor alert-summary-serializer,metrics-endpoints-down,metrics-api-availability,monitoring-statefulsets-recreation,pod-network-avalibility -f -
+openshift-tests run kubernetes/conformance --dry-run | grep -F -v -f /tmp/ignoretests.txt | openshift-tests run -o crc-tmp-install-data/test-artifacts/e2e.log --junit-dir crc-tmp-install-data/test-artifacts/junit --disable-monitor alert-summary-serializer,metrics-endpoints-down,metrics-api-availability,monitoring-statefulsets-recreation,pod-network-avalibility -f -
 rc=$?
 echo "${rc}" > /tmp/test-return
 set -e


### PR DESCRIPTION
Currently the artifacts generated by `openshift-tests` are lost when the pipeline finishes, with this change we move it inside the `crc-tmp-install-data` folder so that it gets uploaded to GCS.