### PR TITLE
[release-4.17]ci: update go version from 1.21 to 1.22

### DIFF
--- a/ci.sh
+++ b/ci.sh
@@ -58,7 +58,7 @@ sudo systemctl reload NetworkManager
 
 git clone https://github.com/code-ready/crc.git
 pushd crc
-podman run --rm -v ${PWD}:/data:Z registry.ci.openshift.org/openshift/release:rhel-8-release-golang-1.21-openshift-4.16 /bin/bash -c "cd /data && make cross"
+podman run --rm -v ${PWD}:/data:Z registry.ci.openshift.org/openshift/release:rhel-8-release-golang-1.22-openshift-4.17 /bin/bash -c "cd /data && make cross"
 sudo mv out/linux-amd64/crc /usr/local/bin/
 popd
 

--- a/ci_microshift.sh
+++ b/ci_microshift.sh
@@ -18,7 +18,7 @@ sudo virsh undefine crc --nvram
 
 git clone https://github.com/crc-org/crc.git
 pushd crc
-podman run --rm -v ${PWD}:/data:Z registry.ci.openshift.org/openshift/release:rhel-8-release-golang-1.21-openshift-4.16 /bin/bash -c "cd /data && make cross"
+podman run --rm -v ${PWD}:/data:Z registry.ci.openshift.org/openshift/release:rhel-8-release-golang-1.22-openshift-4.17 /bin/bash -c "cd /data && make cross"
 sudo mv out/linux-amd64/crc /usr/local/bin/
 popd
 


### PR DESCRIPTION
crc moved to use go-1.22 but here it is built using 1.21 and result to an error.