### PR TITLE
[release-4.17] Update qemu-user-static-x86 to 8.2.6 version

### DIFF
--- a/createdisk.sh
+++ b/createdisk.sh
@@ -127,7 +127,7 @@ if [ "${ARCH}" == "aarch64" ] && [ ${BUNDLE_TYPE} != "okd" ]; then
    # Install qemu-user-static-x86 package from fedora koji to run x86 image on M1
    # Not supported by RHEL https://access.redhat.com/solutions/5654221 and not included
    # in any subscription repo.
-   ${SSH} core@${VM_IP} -- "sudo rpm-ostree install https://kojipkgs.fedoraproject.org//packages/qemu/8.2.4/1.fc40/aarch64/qemu-user-static-x86-8.2.4-1.fc40.aarch64.rpm"
+   ${SSH} core@${VM_IP} -- "sudo rpm-ostree install https://kojipkgs.fedoraproject.org//packages/qemu/8.2.6/3.fc40/aarch64/qemu-user-static-x86-8.2.6-3.fc40.aarch64.rpm"
 fi
 
 cleanup_vm_image ${VM_NAME} ${VM_IP}


### PR DESCRIPTION
Looks like 8.2.4 is deleted https://koji.fedoraproject.org/koji/buildinfo?buildID=2465534 and it cause issue for bundle creation, updating to 8.2.6 https://koji.fedoraproject.org/koji/buildinfo?buildID=2547717