### PR TITLE
Add role for developer user to access resources on default namespace

### DIFF
--- a/developer_role.yaml
+++ b/developer_role.yaml
@@ -1,0 +1,23 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  namespace: default
+  name: developer-role
+rules:
+- apiGroups: ["*"]
+  resources: ["*"]
+  verbs: ["*"]
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: developer-role-binding
+  namespace: default
+subjects:
+  - kind: User
+    name: developer
+    apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: Role
+  name: developer-role
+  apiGroup: rbac.authorization.k8s.io

--- a/snc.sh
+++ b/snc.sh
@@ -223,6 +223,9 @@ retry ${OC} create secret generic htpass-secret --from-file=htpasswd=${HTPASSWD_
 retry ${OC} apply -f oauth_cr.yaml
 retry ${OC} create clusterrolebinding kubeadmin --clusterrole=cluster-admin --user=kubeadmin
 
+# Add role to give developer user access to 'default' namespace
+retry ${OC} apply -f developer_role.yaml
+
 # Remove temp kubeadmin user
 retry ${OC} delete secrets kubeadmin -n kube-system
 


### PR DESCRIPTION
Without this role added, we get the following error when using the `crc-developer` context:

```
% oc project
error: you do not have rights to view project "default" specified in your config or the project doesn't exist

% oc get all -n default
Error from server (Forbidden): pods is forbidden: User "developer" cannot list resource "pods" in API group "" in the namespace "default"
Error from server (Forbidden): replicationcontrollers is forbidden: User "developer" cannot list resource "replicationcontrollers" in API group "" in the namespace "default"
```
After adding the role, rolebinding `developer` user is able to access resources on the namespace:
```
% oc get all -n default
Warning: apps.openshift.io/v1 DeploymentConfig is deprecated in v4.14+, unavailable in v4.10000+
NAME                 TYPE           CLUSTER-IP   EXTERNAL-IP                            PORT(S)   AGE
service/kubernetes   ClusterIP      10.217.4.1   <none>                                 443/TCP   41d
service/openshift    ExternalName   <none>       kubernetes.default.svc.cluster.local   <none>    41d
```

fixes #703