### PR TITLE
Update DEST_DIR_SUFFIX in case of pr

### DIFF
--- a/createdisk-library.sh
+++ b/createdisk-library.sh
@@ -6,7 +6,7 @@ function get_dest_dir_suffix {
     local version=$1
     DEST_DIR_SUFFIX="${version}_${yq_ARCH}"
     if [ -n "${PULL_NUMBER-}" ]; then
-         DEST_DIR_SUFFIX="$DEST_DIR_SUFFIX.pr${PULL_NUMBER}"
+         DEST_DIR_SUFFIX="${DEST_DIR_SUFFIX}_${PULL_NUMBER}"
     fi
 }
 


### PR DESCRIPTION
Recently on crc side[0] we have enabled the regex to capture bundle info and as part of this regex we are capturing the custom bundle which is random generated number like
`crc_okd_vfkit_4.16.7_amd64_2342465234654.crcbundle` but for bundles generated by the pr have suffix `.pr<pr_number>` which means again adjust the regex. We can still identify the bundle with `_<pr_number>` and this way we don't need to update the regex.

- https://github.com/crc-org/crc/pull/4343