### PR TITLE
create macadam-ready bundles

### DIFF
--- a/createdisk-library.sh
+++ b/createdisk-library.sh
@@ -241,6 +241,17 @@ function prepare_qemu_guest_agent() {
     ${SSH} core@${vm_ip} 'sudo systemctl enable qemu-guest-agent.service'
 }
 
+function copy_ready_systemd_units() {
+    local vm_ip=$1
+
+    ${SCP} systemd/* core@${vm_ip}:
+    ${SSH} core@${vm_ip} 'sudo mv -Z *.service /etc/systemd/system/'
+    ${SSH} core@${vm_ip} 'sudo systemctl daemon-reload'
+    ${SSH} core@${vm_ip} 'sudo systemctl enable podman-ready-apple.service'
+    ${SSH} core@${vm_ip} 'sudo systemctl enable podman-ready-microsoft.service'
+    ${SSH} core@${vm_ip} 'sudo systemctl enable podman-ready-kvm.service'
+}
+
 function generate_vfkit_bundle {
     local srcDir=$1
     local destDir=$2

--- a/createdisk.sh
+++ b/createdisk.sh
@@ -91,6 +91,7 @@ if [ "${SNC_GENERATE_WINDOWS_BUNDLE}" != "0" ]; then
 fi
 
 prepare_qemu_guest_agent ${VM_IP}
+copy_ready_systemd_units ${VM_IP}
 
 image_tag="latest"
 if podman manifest inspect quay.io/crcont/routes-controller:${OPENSHIFT_VERSION} >/dev/null 2>&1; then

--- a/systemd/podman-ready-apple.service
+++ b/systemd/podman-ready-apple.service
@@ -1,0 +1,14 @@
+[Unit]
+After=sshd.socket sshd.service
+OnFailure=emergency.target
+OnFailureJobMode=isolate
+Requires=dev-virtio\x2dports-vsock.device
+ConditionVirtualization=apple
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=/bin/sh -c '/usr/bin/echo Ready | socat - VSOCK-CONNECT:2:1025'
+
+[Install]
+RequiredBy=default.target

--- a/systemd/podman-ready-kvm.service
+++ b/systemd/podman-ready-kvm.service
@@ -1,0 +1,14 @@
+[Unit]
+After=sshd.socket sshd.service systemd-user-sessions.service 
+OnFailure=emergency.target
+OnFailureJobMode=isolate
+Requires=dev-virtio\x2dports-vport1p1.device
+ConditionVirtualization=kvm
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=/bin/sh -c '/usr/bin/echo Ready >/dev/vport1p1'
+
+[Install]
+RequiredBy=default.target

--- a/systemd/podman-ready-microsoft.service
+++ b/systemd/podman-ready-microsoft.service
@@ -1,0 +1,18 @@
+[Unit]
+After=sshd.socket sshd.service systemd-user-sessions.service vsock-network.service
+OnFailure=emergency.target
+OnFailureJobMode=isolate
+Requires=sys-devices-virtual-net-vsock0.device
+ConditionVirtualization=microsoft
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+; XXXX is a port number, but podman-machine dynamically allocates it, so we can't hardcode it
+; https://github.com/containers/podman/blob/0712c18d9c6daef2f15e55e4c760c86a22588d03/pkg/machine/hyperv/vsock/vsock.go#L161-L187
+; Either we add that through ignition as podman is doing, or we could set it in a configuration file
+; and overwrite this file at startup, but this is kind of ugly/racy
+ExecStart=/bin/sh -c '/usr/bin/echo Ready | socat - VSOCK-CONNECT:2:XXXX'
+
+[Install]
+RequiredBy=default.target

--- a/tools.sh
+++ b/tools.sh
@@ -195,7 +195,7 @@ function create_libvirt_resources {
 function create_vm {
     local iso=$1
 
-    sudo virt-install \
+    sudo ${VIRT_INSTALL} \
         --name ${SNC_PRODUCT_NAME} \
         --vcpus ${SNC_CLUSTER_CPUS} \
         --memory ${SNC_CLUSTER_MEMORY} \

--- a/tools.sh
+++ b/tools.sh
@@ -203,7 +203,8 @@ function create_vm {
         --disk path=/var/lib/libvirt/${SNC_PRODUCT_NAME}/${SNC_PRODUCT_NAME}.qcow2,size=${CRC_VM_DISK_SIZE} \
         --network network="${SNC_PRODUCT_NAME}",mac=52:54:00:ee:42:e1 \
         --os-variant rhel9-unknown \
-        --nographics \
+        --graphics vnc \
+        --console pty,target.type=virtio \
         --cdrom /var/lib/libvirt/${SNC_PRODUCT_NAME}/${iso} \
         --events on_reboot=restart \
         --autoconsole none \


### PR DESCRIPTION
This adds a few unit files to notify podman machine that the boot is over.
This PR purpose is to generate bundles which can be shared more easily for testing, it is not meant for merging yet.
/hold