### PR TITLE
Set ouath user token expiration time to 365 days

### DIFF
--- a/oauth_cr.yaml
+++ b/oauth_cr.yaml
@@ -4,7 +4,8 @@ metadata:
   name: cluster
 spec:
   tokenConfig:
-    accessTokenMaxAgeSeconds: 0
+    # token max age set to 365 days
+    accessTokenMaxAgeSeconds: 31536000
   identityProviders:
   - name: developer
     mappingMethod: claim 


### PR DESCRIPTION
With [1] it was attempted to set token expiration to infinite but as described in [2] with the config set to 0, token expiration is set to default i.e 24 hours. With this patch setting it to a larger value i.e 365 days.

[1] https://github.com/crc-org/snc/pull/332
[2] https://bugzilla.redhat.com/show_bug.cgi?id=1959776
Related-Issue: #331