### PR TITLE
Remove initramfs/vmlinuz references for mac bundles

### DIFF
--- a/crc-bundle-info.json.sample
+++ b/crc-bundle-info.json.sample
@@ -9,7 +9,7 @@
   # - 1.3: remove of 'clusterInfo.kubeadminPasswordFile'
   # - 1.4: addition of 'arch'
   # - 1.5: remove of 'node[0].kernelCmdLine', 'node[0].initramfs', 'node[0].kernel'
-  "version": "1.4",
+  "version": "1.5",
   # Type of this bundle content
   # Currently the only valid type is 'snc' (which stands for 'single-node-cluster')
   "type": "snc",

--- a/crc-bundle-info.json.sample
+++ b/crc-bundle-info.json.sample
@@ -8,6 +8,7 @@
   # - 1.2: addition of 'storage.fileList'
   # - 1.3: remove of 'clusterInfo.kubeadminPasswordFile'
   # - 1.4: addition of 'arch'
+  # - 1.5: remove of 'node[0].kernelCmdLine', 'node[0].initramfs', 'node[0].kernel'
   "version": "1.4",
   # Type of this bundle content
   # Currently the only valid type is 'snc' (which stands for 'single-node-cluster')
@@ -56,12 +57,6 @@
       "diskImage": "crc.qcow2"
       # Internal IP for which etcd certs are valid
       "internalIP": "192.168.126.11"
-      # kernel command line of the node
-      "kernelCmdLine": "BOOT_IMAGE=/ostree/rhcos-bf3b38268ddb2a2070dc587b361ce45c46a6f9e3606bbd3b5e15b2e6d3d47e5d/vmlinuz-4.18.0-80.1.2.el8_0.x86_64 console=tty0 console=ttyS0,115200n8 rootflags=defaults,prjquota rw root=UUID=a8fbdcb1-63ea-421e-8f6f-dac9cbbcc822 ostree=/ostree/boot.0/rhcos/bf3b38268ddb2a2070dc587b361ce45c46a6f9e3606bbd3b5e15b2e6d3d47e5d/0 coreos.oem.id=qemu ignition.platform.id=qemu"
-      # initramfs file of the node
-      "initramfs": "initramfs-4.18.0-80.1.2.el8_0.x86_64.img"
-      # kernel file of the node
-      "kernel": "vmlinuz-4.18.0-80.1.2.el8_0.x86_64"
     }
   ],
   "storage": {

--- a/createdisk.sh
+++ b/createdisk.sh
@@ -144,22 +144,6 @@ fi
 
 podman_version=$(${SSH} core@${VM_IP} -- 'rpm -q --qf %{version} podman')
 
-# Get the rhcos ostree Hash ID
-ostree_hash=$(${SSH} core@${VM_IP} -- "cat /proc/cmdline | grep -oP \"(?<=${BASE_OS}-).*(?=/vmlinuz)\"")
-
-# Get the rhcos kernel release
-kernel_release=$(${SSH} core@${VM_IP} -- 'uname -r')
-
-# Get the kernel command line arguments
-kernel_cmd_line=$(${SSH} core@${VM_IP} -- 'cat /proc/cmdline')
-
-# Get the vmlinux/initramfs to /tmp/kernel and change permission for initramfs
-${SSH} core@${VM_IP} -- "mkdir /tmp/kernel && sudo cp -r /boot/ostree/${BASE_OS}-${ostree_hash}/*${kernel_release}* /tmp/kernel && sudo chmod 644 /tmp/kernel/initramfs*"
-
-# SCP the vmlinuz/initramfs from VM to Host in provided folder.
-${SCP} -r core@${VM_IP}:/tmp/kernel/* $INSTALL_DIR
-${SSH} core@${VM_IP} -- "sudo rm -fr /tmp/kernel"
-
 # Shutdown the VM
 shutdown_vm ${VM_NAME}
 
@@ -196,9 +180,5 @@ fi
 if [ "${SNC_GENERATE_MACOS_BUNDLE}" != "0" ]; then
     vfkitDestDir="${destDirPrefix}_vfkit_${destDirSuffix}"
     rm -fr ${vfkitDestDir} ${vfkitDestDir}.crcbundle
-    generate_vfkit_bundle "$libvirtDestDir" "$vfkitDestDir" "$INSTALL_DIR" "$kernel_release" "$kernel_cmd_line"
-
-    # Cleanup up vmlinux/initramfs files
-    rm -fr "$INSTALL_DIR/vmlinuz*" "$INSTALL_DIR/initramfs*"
+    generate_vfkit_bundle "$libvirtDestDir" "$vfkitDestDir"
 fi
-

--- a/repos/mirror-microshift.repo
+++ b/repos/mirror-microshift.repo
@@ -1,5 +1,5 @@
 [mirror-microshift]
 name=microshift repo for mirror
-baseurl=https://mirror.openshift.com/pub/openshift-v4/$basearch/microshift/ocp-dev-preview/latest-4.17/el9/os/
+baseurl=https://mirror.openshift.com/pub/openshift-v4/$basearch/microshift/ocp-dev-preview/latest-4.19/el9/os/
 enabled=1
 gpgcheck=0

--- a/test-metadata-generation.sh
+++ b/test-metadata-generation.sh
@@ -27,8 +27,7 @@ mkdir -p "$srcDir"
 mkdir -p "$srcDir/auth"
 touch "$srcDir"/auth/kubeconfig
 touch id_ecdsa_crc
-touch "$srcDir"/vmlinuz-0.0.0
-touch "$srcDir"/initramfs-0.0.0.img
+
 
 echo {} | ${JQ} '.version = "1.2"' \
     | ${JQ} '.type = "snc"' \


### PR DESCRIPTION
After https://github.com/crc-org/crc/pull/4309 we don't need to use those references for running the bundle on macOS so better to remove this unused code/reference.

fixes: #992