### PR TITLE
Add logic to make filesystem immutable for directory sharing from host

### DIFF
--- a/99_master-create-users-symlink.yaml
+++ b/99_master-create-users-symlink.yaml
@@ -1,0 +1,60 @@
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfig
+metadata:
+  labels:
+    machineconfiguration.openshift.io/role: master
+  name: 99-openshift-machineconfig-master-users-symlink
+spec:
+  config:
+    ignition:
+      version: 3.4.0
+    systemd:
+      units:
+      - contents: |
+          [Unit]
+          Description=Allow systemd to create mount points on /
+          DefaultDependencies=no
+          Before=remote-fs.target
+
+          [Service]
+          Type=oneshot
+          ExecStart=chattr -i /
+
+          [Install]
+          WantedBy=remote-fs.target
+        enabled: true
+        name: immutable-root-off.service
+      - contents: |
+          [Unit]
+          Description=Set / back to immutable after mounts are done
+          DefaultDependencies=no
+          After=remote-fs.target
+
+          [Service]
+          Type=oneshot
+          ExecStart=chattr +i /
+
+          [Install]
+          WantedBy=remote-fs.target
+        enabled: true
+        name: immutable-root-on.service
+      - contents: |
+          [Unit]
+          Description=Create Users directory and mount to var
+          After=immutable-root-off.service
+          Before=immutable-root-on.service
+
+          [Service]
+          Type=oneshot
+          ExecStartPre=rm -f /Users
+          ExecStartPre=mkdir -p /var/Users
+          ExecStart=ln -sf /var/Users /Users 
+
+          [Install]
+          WantedBy=multi-user.target
+        enabled: true
+        name: create-symlink-users.service
+    networkd: {}
+    passwd: {}
+    storage: {}
+    osImageURL: ""

--- a/snc.sh
+++ b/snc.sh
@@ -147,6 +147,10 @@ cp cluster-network-03-config.yaml ${INSTALL_DIR}/manifests/
 cp 99_master-chronyd-mask.yaml $INSTALL_DIR/openshift/
 # Add dummy network unit file
 cp 99-openshift-machineconfig-master-dummy-networks.yaml $INSTALL_DIR/openshift/
+# Add unit file for creating /Users and symlink it to /var/Users
+# It is used for mounting shared directory on Mac
+# https://github.com/coreos/rpm-ostree/issues/337
+cp 99_master-create-users-symlink.yaml $INSTALL_DIR/openshift/
 # Add kubelet config resource to make change in kubelet
 DYNAMIC_DATA=$(base64 -w0 node-sizing-enabled.env) envsubst < 99_master-node-sizing-enabled-env.yaml.in > $INSTALL_DIR/openshift/99_master-node-sizing-enabled-env.yaml
 # Add codeReadyContainer as invoker to identify it with telemeter


### PR DESCRIPTION
As part of `enable-shared-dirs`, in crc codebase we first make it mutable and then create top level directory for mount and again make it immutable. This is we are doing only for Mac because for linux it is $HOME and for windows we are mounting it under `/mnt`. In RHCOS `/home` and `/mnt` is already symlink to `/var/home` and `/var/mnt` which is by default mutable. So for mac we only need `/Users` to be symlink to `/var/Users`. We can remove that code on crc side during shared directories.

Another motivation is as part of `image-mode` base system `chattr` is not going to make system mutable for rootfs and there also we are going to use same workaround (make /Users to symlink to `/var`). This way both the bundle should behave same way.