### PR TITLE
ci_microshift: Remove PRERELEASE flag for 4.17

### DIFF
--- a/ci_microshift.sh
+++ b/ci_microshift.sh
@@ -5,7 +5,7 @@ set -exuo pipefail
 sudo yum install -y make golang
 
 ./shellcheck.sh
-MICROSHIFT_PRERELEASE=yes ./microshift.sh
+./microshift.sh
 
 # Set the zstd compression level to 10 to have faster
 # compression while keeping a reasonable bundle size.


### PR DESCRIPTION
4.17 is already released so better to consume whatever available as part of public release instead from mirror which doesn't get updated once public release happen.