### PR TITLE
Don't remove network pods from etcd db during cleanup

### DIFF
--- a/createdisk.sh
+++ b/createdisk.sh
@@ -139,12 +139,17 @@ fi
 
 cleanup_vm_image ${VM_NAME} ${VM_IP}
 
-# Delete all the pods and lease from the etcd db so that when this bundle is use for the cluster provision, everything comes up in clean state.
+# Delete all the pods except openshift-multus (which have file for crio cni config)
+# and lease from the etcd db so that when this bundle is use for the cluster provision, everything comes up in clean state.
 if [ ${BUNDLE_TYPE} != "microshift" ]; then
     etcd_image=$(${SSH} core@${VM_IP} -- "sudo jq -r '.spec.containers[] | select(.name == \"etcd\") | .image' /etc/kubernetes/manifests/etcd-pod.yaml")
     ${SSH} core@${VM_IP} -- "sudo podman run --rm --network=host --privileged --replace --name crc-etcd --detach --entrypoint etcd -v /var/lib/etcd:/store \"${etcd_image}\" --data-dir /store"
     sleep 5
-    ${SSH} core@${VM_IP} -- "sudo podman exec crc-etcd etcdctl del --prefix /kubernetes.io/pods"
+    ${SSH} core@${VM_IP} 'sudo bash -x -s' << EOF
+podman exec crc-etcd etcdctl get /kubernetes.io/pods/ --prefix --keys-only | \
+grep -v "^/kubernetes.io/pods/openshift-network" | \
+xargs -I {} podman exec crc-etcd etcdctl del "{}"
+EOF
     ${SSH} core@${VM_IP} -- "sudo podman exec crc-etcd etcdctl del --prefix /kubernetes.io/leases"
     ${SSH} core@${VM_IP} -- "sudo podman stop crc-etcd"
 fi


### PR DESCRIPTION
When debugging the cert rotation failure found out that because we
remove the network pods so as part of crio cleanup all data around this
pod is also get removed and it can't start. If cert is not
expire this can be again created automatic hence we never had issue but
in case kubelet-serving certs expire then node is not ready and there
is no network config so it become a dead lock since crio started but not
with that config and also openshift started but not able recreate this
config on disk.