### PR TITLE
microshift: Create symlink of /usr/local to make is mutable

### DIFF
--- a/image-mode/microshift/config/Containerfile.bootc-rhel9
+++ b/image-mode/microshift/config/Containerfile.bootc-rhel9
@@ -23,3 +23,4 @@ RUN dnf install -y firewalld microshift microshift-release-info cloud-utils-grow
 # and both are symlink to `var` already
 RUN rm -fr /opt && ln -sf var/opt /opt && mkdir /var/opt
 RUN ln -sf var/Users /Users && mkdir /var/Users
+RUN rm -fr /usr/local && ln -sf ../var/usrlocal /usr/local && mkdir /var/usrlocal


### PR DESCRIPTION
This will allow us to place different scripts which is going to used for self sufficient bundle to `/usr/local/bin` same way it is allowed in the openshift bundles because there also it is symlinked
```
total 136
[...]
lrwxrwxrwx.   2 root root    15 Aug  1  2022 local -> ../var/usrlocal
```