### PR TITLE
use the same apps domain for both ocp and microshift

### DIFF
--- a/snc-library.sh
+++ b/snc-library.sh
@@ -136,7 +136,6 @@ function create_json_description {
         tmp=$(mktemp)
         cat ${INSTALL_DIR}/crc-bundle-info.json \
             | ${JQ} ".buildInfo.openshiftInstallerVersion = \"${openshiftInstallerVersion}\"" \
-            | ${JQ} ".clusterInfo.appsDomain = \"apps-${SNC_PRODUCT_NAME}.${BASE_DOMAIN}\"" \
             > ${tmp} && mv ${tmp} ${INSTALL_DIR}/crc-bundle-info.json
     fi
 }


### PR DESCRIPTION
since we don't have any requirement to keep the apps domain for ocp to be `apps-crc.testing` while making it same for both 'ocp' and 'microshift' means we can use the  dnsmasq config for both