### PR TITLE
microshift: Use no-cache option for microshift image build

### DIFF
--- a/image-mode/microshift/build.sh
+++ b/image-mode/microshift/build.sh
@@ -134,7 +134,7 @@ cat < "${SCRIPTDIR}/config/config.toml.template" \
     > "${BUILDDIR}"/config.toml
 
 title "Building bootc image for microshift"
-sudo podman build --authfile ${OCP_PULL_SECRET_FILE} -t ${IMGNAME}:${MICROSHIFT_VERSION}  \
+sudo podman build --no-cache --authfile ${OCP_PULL_SECRET_FILE} -t ${IMGNAME}:${MICROSHIFT_VERSION}  \
   --build-arg MICROSHIFT_VER=${MICROSHIFT_VERSION} \
   --env UNRELEASED_MIRROR_REPO=${USE_UNRELEASED_MIRROR_REPO} \
   -f "${SCRIPTDIR}/config/Containerfile.bootc-rhel9"


### PR DESCRIPTION
By default podman uses the cache to build image and since we are using same node that means cached layer is already exist and old microshift package installed instead of latest one.