### PR TITLE
Use quadlet and start gvisor-tap-vsock before nodeip-configuration service 

### DIFF
--- a/createdisk.sh
+++ b/createdisk.sh
@@ -100,6 +100,7 @@ ${SSH} core@${VM_IP} 'sudo bash -x -s' <<EOF
   cat > /etc/containers/systemd/gvisor-tap-vsock.container <<EOF1
 [Unit]
 Description=gvisor-tap-vsock
+Before=nodeip-configuration.service
 
 [Container]
 Image=quay.io/crcont/gvisor-tap-vsock:latest

--- a/createdisk.sh
+++ b/createdisk.sh
@@ -96,10 +96,20 @@ fi
 
 # Add gvisor-tap-vsock service
 ${SSH} core@${VM_IP} 'sudo bash -x -s' <<EOF
-  podman create --name=gvisor-tap-vsock --privileged --net=host -v /etc/resolv.conf:/etc/resolv.conf -it quay.io/crcont/gvisor-tap-vsock:latest
-  podman generate systemd --restart-policy=no gvisor-tap-vsock > /etc/systemd/system/gvisor-tap-vsock.service
-  systemctl daemon-reload
-  systemctl enable gvisor-tap-vsock.service
+  podman pull quay.io/crcont/gvisor-tap-vsock:latest
+  cat > /etc/containers/systemd/gvisor-tap-vsock.container <<EOF1
+[Unit]
+Description=gvisor-tap-vsock
+
+[Container]
+Image=quay.io/crcont/gvisor-tap-vsock:latest
+Network=host
+PodmanArgs=--interactive --privileged --tty
+Volume=/etc/resolv.conf:/etc/resolv.conf
+
+[Install]
+WantedBy=default.target
+EOF1
 EOF
 
 # Add dummy crio-wipe service to instance


### PR DESCRIPTION
## Summary by Sourcery

Migrate gvisor-tap-vsock service configuration from traditional systemd service to quadlet container configuration

Enhancements:
- Modify service startup to use quadlet container configuration
- Add explicit service ordering with nodeip-configuration service

Chores:
- Update gvisor-tap-vsock service deployment method