### PR TITLE
build-patch: Check if brew build exist is not failed one

### DIFF
--- a/build-patched-kao-kcmo-images.sh
+++ b/build-patched-kao-kcmo-images.sh
@@ -87,7 +87,7 @@ function patch_and_push_image() {
     version=$(${OC} image info -a ${OPENSHIFT_PULL_SECRET_PATH} ${image} -ojson | jq -r '.config.config.Labels.version')
     release=$(${OC} image info -a ${OPENSHIFT_PULL_SECRET_PATH} ${image} -ojson | jq -r '.config.config.Labels.release')
     # If brew build already exist for the release don't rebuild it again
-    if ! brew buildinfo crc-${image_name}-container-${version}-${release}; then
+    if ! brew buildinfo crc-${image_name}-container-${version}-${release} | grep "State: COMPLETE" ; then
         rhpkg clone containers/crc-${image_name}
         pushd crc-${image_name}
         git remote add upstream https://pkgs.devel.redhat.com/git/containers/ose-${image_name}


### PR DESCRIPTION
If brew build fails then there is no image artifacts but this doesn't make script to rerun the brew build and failed. This PR adds a check about the status of the build and make sure if the status is complete then only don't run the brew build step.

## Summary by Sourcery

Bug Fixes:
- Modify brew build existence check to also verify "State: COMPLETE" before skipping the build step.