### PR TITLE
CI: Use debug as log level for crc start

### DIFF
--- a/ci.sh
+++ b/ci.sh
@@ -64,7 +64,7 @@ popd
 
 crc config set bundle crc_libvirt_*.crcbundle
 crc setup
-crc start --disk-size 80 -m 24000 -c 10 -p "${HOME}"/pull-secret
+crc start --disk-size 80 -m 24000 -c 10 -p "${HOME}"/pull-secret --log-level debug
 
 mkdir -p crc-tmp-install-data/test-artifacts
 export KUBECONFIG="${HOME}"/.crc/machines/crc/kubeconfig

--- a/ci_microshift.sh
+++ b/ci_microshift.sh
@@ -25,7 +25,7 @@ popd
 crc config set bundle crc_microshift_libvirt_*.crcbundle
 crc config set preset microshift
 crc setup
-crc start -p "${HOME}"/pull-secret
+crc start -p "${HOME}"/pull-secret --log-level debug
 
 rc=$?
 echo "${rc}" > /tmp/test-return


### PR DESCRIPTION
Looks like without debug message it is hard to find which stage actually failed or hanged, took some time to figure out start hangs because of NetworkManager instead Configure shared directory.

- https://github.com/crc-org/snc/issues/1068