### PR TITLE
Disable the ipv6 for tap0 connection

### DIFF
--- a/createdisk.sh
+++ b/createdisk.sh
@@ -98,7 +98,7 @@ fi
 # this mac address is used to allocate a specific IP to the VM
 # when tap device is in use.
 ${SSH} core@${VM_IP} 'sudo bash -x -s' <<EOF
-  nmcli connection add type tun ifname tap0 con-name tap0 mode tap autoconnect yes 802-3-ethernet.cloned-mac-address 5A:94:EF:E4:0C:EE
+  nmcli connection add type tun ifname tap0 con-name tap0 mode tap autoconnect yes 802-3-ethernet.cloned-mac-address 5A:94:EF:E4:0C:EE ipv6.method "disabled"
 EOF
 
 


### PR DESCRIPTION
During Network restart looks like it also try to assign ipv6 for tap0 so disabling it.

## Summary by Sourcery

Bug Fixes:
- Disable IPv6 on the tap0 connection to avoid unexpected IPv6 addressing during network restarts