### PR TITLE
Don't add device checks for tap0 service

### DIFF
--- a/createdisk.sh
+++ b/createdisk.sh
@@ -107,14 +107,13 @@ ${SSH} core@${VM_IP} 'sudo bash -x -s' <<EOF
   tee /etc/systemd/system/gv-user-network@.service <<TEE
 [Unit]
 Description=gvisor-tap-vsock Network Traffic Forwarder
-After=NetworkManager.service
-BindsTo=sys-devices-virtual-net-%i.device
 After=sys-devices-virtual-net-%i.device
 
 [Service]
 Restart=on-failure
 Environment="GV_VSOCK_PORT=1024"
 EnvironmentFile=-/etc/sysconfig/gv-user-network
+ExecStartPre=/bin/sh -c 'for i in {1..10}; do ip link show "\\\$1" && exit 0; sleep 1; done; exit 1' _ %i
 ExecStart=/usr/libexec/podman/gvforwarder -preexisting -iface %i -url vsock://2:"\\\${GV_VSOCK_PORT}"/connect
 
 [Install]


### PR DESCRIPTION
Instead use `ExecStartPre` to check if tap0 exist with a retry loop for 10 sec. During failure `timeout waiting for device /sys/class/net/tap0` error is observed which means that device was not available and check failed. so instead of device check let's see if this make it work.


Let's see if that fix the CI.

## Summary by Sourcery

Replace systemd templated gv-user-network unit with a dedicated gvisor-tap-vsock.service that waits for the tap0 interface via an ExecStartPre retry loop instead of relying on device unit bindings and update service installation accordingly.

Enhancements:
- Rename templated gv-user-network@.service to a single gvisor-tap-vsock.service
- Remove BindsTo and After device unit dependencies for tap0
- Add an ExecStartPre loop to retry checking for the tap0 interface up to 10 seconds
- Update ExecStart to use a fixed tap0 interface and adjust systemctl enable invocation