### PR TITLE
[release-4.19] Use kubelet rotation 4.19

### DIFF
--- a/kubelet-bootstrap-cred-manager-ds.yaml
+++ b/kubelet-bootstrap-cred-manager-ds.yaml
@@ -1,0 +1,108 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: kubelet-bootstrap-cred-manager
+  namespace: openshift-machine-config-operator
+  labels:
+    k8s-app: kubelet-bootrap-cred-manager
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      k8s-app: kubelet-bootstrap-cred-manager
+  template:
+    metadata:
+      labels:
+        k8s-app: kubelet-bootstrap-cred-manager
+    spec:
+      containers:
+      - name: kubelet-bootstrap-cred-manager
+        image: quay.io/openshift/origin-cli:latest
+        command: ['/bin/bash', '-ec']
+        args:
+          - |
+            #!/bin/bash
+
+            set -eoux pipefail
+
+            while true; do
+              unset KUBECONFIG
+
+              echo "----------------------------------------------------------------------"
+              echo "Gather info..."
+              echo "----------------------------------------------------------------------"
+              # context
+              intapi=$(oc get infrastructures.config.openshift.io cluster -o "jsonpath={.status.apiServerInternalURI}")
+              context="$(oc --config=/etc/kubernetes/kubeconfig config current-context)"
+              # cluster
+              cluster="$(oc --config=/etc/kubernetes/kubeconfig config view -o "jsonpath={.contexts[?(@.name==\"$context\")].context.cluster}")"
+              server="$(oc --config=/etc/kubernetes/kubeconfig config view -o "jsonpath={.clusters[?(@.name==\"$cluster\")].cluster.server}")"
+              # token
+              ca_crt_data="$(oc get secret -n openshift-machine-config-operator node-bootstrapper-token -o "jsonpath={.data.ca\.crt}" | base64 --decode)"
+              namespace="$(oc get secret -n openshift-machine-config-operator node-bootstrapper-token  -o "jsonpath={.data.namespace}" | base64 --decode)"
+              token="$(oc get secret -n openshift-machine-config-operator node-bootstrapper-token -o "jsonpath={.data.token}" | base64 --decode)"
+
+              echo "----------------------------------------------------------------------"
+              echo "Generate kubeconfig"
+              echo "----------------------------------------------------------------------"
+
+              export KUBECONFIG="$(mktemp)"
+              kubectl config set-credentials "kubelet" --token="$token" >/dev/null
+              ca_crt="$(mktemp)"; echo "$ca_crt_data" > $ca_crt
+              kubectl config set-cluster $cluster --server="$intapi" --certificate-authority="$ca_crt" --embed-certs >/dev/null
+              kubectl config set-context kubelet --cluster="$cluster" --user="kubelet" >/dev/null
+              kubectl config use-context kubelet >/dev/null
+
+              echo "----------------------------------------------------------------------"
+              echo "Print kubeconfig"
+              echo "----------------------------------------------------------------------"
+              cat "$KUBECONFIG"
+
+              echo "----------------------------------------------------------------------"
+              echo "Whoami?"
+              echo "----------------------------------------------------------------------"
+              oc whoami
+              whoami
+
+              echo "----------------------------------------------------------------------"
+              echo "Moving to real kubeconfig"
+              echo "----------------------------------------------------------------------"
+              cp /etc/kubernetes/kubeconfig /etc/kubernetes/kubeconfig.prev
+              chown root:root ${KUBECONFIG}
+              chmod 0644 ${KUBECONFIG}
+              mv "${KUBECONFIG}" /etc/kubernetes/kubeconfig
+
+              echo "----------------------------------------------------------------------"
+              echo "Sleep 60 seconds..."
+              echo "----------------------------------------------------------------------"
+              sleep 60
+            done
+        securityContext:
+          privileged: true
+          runAsUser: 0
+        volumeMounts:
+          - mountPath: /etc/kubernetes/
+            name: kubelet-dir
+      nodeSelector:
+        node-role.kubernetes.io/master: ""
+      priorityClassName: "system-cluster-critical"
+      restartPolicy: Always
+      securityContext:
+        runAsUser: 0
+      tolerations:
+      - key: "node-role.kubernetes.io/master"
+        operator: "Exists"
+        effect: "NoSchedule"
+      - key: "node.kubernetes.io/unreachable"
+        operator: "Exists"
+        effect: "NoExecute"
+        tolerationSeconds: 120
+      - key: "node.kubernetes.io/not-ready"
+        operator: "Exists"
+        effect: "NoExecute"
+        tolerationSeconds: 120
+      volumes:
+        - hostPath:
+            path: /etc/kubernetes/
+            type: Directory
+          name: kubelet-dir

--- a/microshift.sh
+++ b/microshift.sh
@@ -15,9 +15,9 @@ SNC_CLUSTER_MEMORY=${SNC_CLUSTER_MEMORY:-2048}
 SNC_CLUSTER_CPUS=${SNC_CLUSTER_CPUS:-2}
 CRC_VM_DISK_SIZE=${CRC_VM_DISK_SIZE:-31}
 BASE_DOMAIN=${CRC_BASE_DOMAIN:-testing}
-MIRROR=${MIRROR:-https://mirror.openshift.com/pub/openshift-v4/$ARCH/clients/ocp-dev-preview}
+MIRROR=${MIRROR:-https://mirror.openshift.com/pub/openshift-v4/$ARCH/clients/ocp}
 MICROSHIFT_VERSION=${MICROSHIFT_VERSION:-4.19}
-MIRROR_REPO=${MIRROR_REPO:-https://mirror.openshift.com/pub/openshift-v4/$ARCH/microshift/ocp-dev-preview/latest-${MICROSHIFT_VERSION}/el9/os}
+MIRROR_REPO=${MIRROR_REPO:-https://mirror.openshift.com/pub/openshift-v4/$ARCH/microshift/ocp/latest-${MICROSHIFT_VERSION}/el9/os}
 
 echo "Check if system is registered"
 # Check the subscription status and register if necessary

--- a/repos/mirror-microshift.repo
+++ b/repos/mirror-microshift.repo
@@ -1,5 +1,5 @@
 [mirror-microshift]
 name=microshift repo for mirror
-baseurl=https://mirror.openshift.com/pub/openshift-v4/$basearch/microshift/ocp-dev-preview/latest-4.19/el9/os/
+baseurl=https://mirror.openshift.com/pub/openshift-v4/$basearch/microshift/ocp/latest-4.19/el9/os/
 enabled=1
 gpgcheck=0

--- a/snc.sh
+++ b/snc.sh
@@ -31,7 +31,7 @@ BASE_DOMAIN=${CRC_BASE_DOMAIN:-testing}
 CRC_PV_DIR="/mnt/pv-data"
 SSH="ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i id_ecdsa_crc"
 SCP="scp -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i id_ecdsa_crc"
-MIRROR=${MIRROR:-https://mirror.openshift.com/pub/openshift-v4/$ARCH/clients/ocp-dev-preview}
+MIRROR=${MIRROR:-https://mirror.openshift.com/pub/openshift-v4/$ARCH/clients/ocp}
 CERT_ROTATION=${SNC_DISABLE_CERT_ROTATION:-enabled}
 USE_PATCHED_RELEASE_IMAGE=${SNC_USE_PATCHED_RELEASE_IMAGE:-disabled}
 HTPASSWD_FILE='users.htpasswd'

--- a/snc.sh
+++ b/snc.sh
@@ -175,6 +175,12 @@ create_vm rhcos-live.iso
 
 ${OPENSHIFT_INSTALL} --dir ${INSTALL_DIR} wait-for install-complete ${OPENSHIFT_INSTALL_EXTRA_ARGS} || ${OC} adm must-gather --dest-dir ${INSTALL_DIR}
 
+# Steps from https://www.redhat.com/en/blog/enabling-openshift-4-clusters-to-stop-and-resume-cluster-vms
+# which provide details how to rotate certs without wait for 24h
+retry ${OC} apply -f kubelet-bootstrap-cred-manager-ds.yaml
+retry ${OC} delete secrets/csr-signer-signer secrets/csr-signer -n openshift-kube-controller-manager-operator
+retry ${OC} adm wait-for-stable-cluster
+
 if [[ ${CERT_ROTATION} == "enabled" ]]
 then
     renew_certificates
@@ -182,6 +188,10 @@ fi
 
 # Wait for install to complete, this provide another 30 mins to make resources (apis) stable
 ${OPENSHIFT_INSTALL} --dir ${INSTALL_DIR} wait-for install-complete ${OPENSHIFT_INSTALL_EXTRA_ARGS}
+
+# Remove the bootstrap-cred-manager daemonset and wait till it get deleted
+retry ${OC} delete daemonset.apps/kubelet-bootstrap-cred-manager -n openshift-machine-config-operator
+retry ${OC} wait --for=delete daemonset.apps/kubelet-bootstrap-cred-manager --timeout=60s -n openshift-machine-config-operator
 
 # Set the VM static hostname to crc-xxxxx-master-0 instead of localhost.localdomain
 HOSTNAME=$(${SSH} core@api.${SNC_PRODUCT_NAME}.${BASE_DOMAIN} hostnamectl status --transient)


### PR DESCRIPTION
## Summary by Sourcery

Enable kubelet certificate auto-rotation for OpenShift 4.19 by deploying a bootstrap credential manager and integrate its workflow into the snc.sh and microshift.sh scripts while updating default mirror URLs.

New Features:
- Automate kubelet bootstrap credential generation and replacement via a new kubelet-bootstrap-cred-manager DaemonSet
- Add script steps to perform immediate certificate rotation in snc.sh using the bootstrap cred manager without waiting 24 hours

Enhancements:
- Update default mirror URLs in snc.sh and microshift.sh to point to the stable OpenShift 4 (ocp) repository
- Set default MicroShift version to 4.19 and adjust the corresponding repository path