### PR TITLE
Fixes okd bits which make sure okd build happen successfully 

### DIFF
--- a/snc-library.sh
+++ b/snc-library.sh
@@ -43,14 +43,7 @@ function download_oc() {
     fi
     if [ "${SNC_GENERATE_WINDOWS_BUNDLE}" != "0" ]; then
         mkdir -p openshift-clients/windows
-        if [ "${BUNDLE_TYPE}" == "okd" ]; then
-            # Extract oc client for windows until it is fixed on scos side and part of artifacts like mac and Linux
-            # https://github.com/okd-project/okd-scos/issues/17
-            ${OC} adm release extract --tools --command-os windows --to openshift-clients/windows  quay.io/okd/scos-release:${OPENSHIFT_RELEASE_VERSION}
-            mv openshift-clients/windows/*.zip openshift-clients/windows/oc.zip
-        else
-            curl -L "${MIRROR}/${OPENSHIFT_RELEASE_VERSION}/openshift-client-windows-${OPENSHIFT_RELEASE_VERSION}.zip" > openshift-clients/windows/oc.zip
-        fi
+        curl -L "${MIRROR}/${OPENSHIFT_RELEASE_VERSION}/openshift-client-windows-${OPENSHIFT_RELEASE_VERSION}.zip" > openshift-clients/windows/oc.zip
         ${UNZIP} -o -d openshift-clients/windows/ openshift-clients/windows/oc.zip
     fi
 }

--- a/snc.sh
+++ b/snc.sh
@@ -18,7 +18,7 @@ BUNDLE_TYPE="snc"
 if [[ ${OKD_VERSION} != "none" ]]
 then
     OPENSHIFT_VERSION=${OKD_VERSION}
-    MIRROR=${MIRROR:-https://github.com/okd-project/okd-scos/releases/download}
+    MIRROR=${MIRROR:-https://github.com/okd-project/okd/releases/download}
     BUNDLE_TYPE="okd"
 fi
 

--- a/snc.sh
+++ b/snc.sh
@@ -247,7 +247,11 @@ wait_till_cluster_stable
 # Unsetting KUBECONFIG is required because it has default `system:admin` user which doesn't able to create
 # token to login to registry and kubeadmin user is required for that.
 unset KUBECONFIG
-RHCOS_IMAGE=$(${OC} adm release info -a ${OPENSHIFT_PULL_SECRET_PATH} ${OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE} --image-for=rhel-coreos)
+if [[ ${BUNDLE_TYPE} == "okd" ]]; then
+     RHCOS_IMAGE=$(${OC} adm release info -a ${OPENSHIFT_PULL_SECRET_PATH} ${OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE} --image-for=stream-coreos)
+else
+     RHCOS_IMAGE=$(${OC} adm release info -a ${OPENSHIFT_PULL_SECRET_PATH} ${OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE} --image-for=rhel-coreos)
+fi
 cat << EOF > ${INSTALL_DIR}/Containerfile
 FROM scratch
 RUN ln -sf var/Users /Users && mkdir /var/Users

--- a/tools.sh
+++ b/tools.sh
@@ -195,6 +195,11 @@ function create_libvirt_resources {
 function create_vm {
     local iso=$1
 
+    bootOption=""
+    if ${BUNDLE_TYPE} != "okd"; then
+        bootOption="--boot uefi"
+    fi
+
     sudo virt-install \
         --name ${SNC_PRODUCT_NAME} \
         --vcpus ${SNC_CLUSTER_CPUS} \
@@ -207,7 +212,7 @@ function create_vm {
         --cdrom /var/lib/libvirt/${SNC_PRODUCT_NAME}/${iso} \
         --events on_reboot=restart \
         --autoconsole none \
-        --boot uefi \
+        ${bootOption} \
         --wait
 }
 


### PR DESCRIPTION
## Summary by Sourcery

Update OKD-specific automation to ensure build and installation succeed by standardizing client retrieval, VM configuration, mirror URL, and image selection.

Bug Fixes:
- Unify Windows oc client download via curl instead of conditional oc adm extract for OKD bundles.

Enhancements:
- Make UEFI boot optional and disable it for OKD VMs.
- Update default OKD mirror URL to github.com/okd/releases.
- Select ‘stream-coreos’ image for OKD clusters instead of ‘rhel-coreos’.