### PR TITLE
Add missing services for self sufficient bundle

### DIFF
--- a/systemd/crc-cluster-status.service
+++ b/systemd/crc-cluster-status.service
@@ -1,7 +1,9 @@
 [Unit]
 Description=CRC Unit checking if cluster is ready
-After=kubelet.service ocp-clusterid.service ocp-cluster-ca.service ocp-custom-domain.service
-After=crc-pullsecret.service
+After=crc-wait-apiserver-up.service crc-pullsecret.service
+After=ocp-mco-sshkey.service ocp-cluster-ca.service
+After=ocp-custom-domain.service ocp-userpasswords.service
+After=ocp-clusterid.service
 
 [Service]
 Type=oneshot

--- a/systemd/crc-cluster-status.service
+++ b/systemd/crc-cluster-status.service
@@ -4,10 +4,13 @@ After=crc-wait-apiserver-up.service crc-pullsecret.service
 After=ocp-mco-sshkey.service ocp-cluster-ca.service
 After=ocp-custom-domain.service ocp-userpasswords.service
 After=ocp-clusterid.service
+StartLimitIntervalSec=450
+StartLimitBurst=10
 
 [Service]
 Type=oneshot
 Restart=on-failure
+RestartSec=40
 ExecCondition=/usr/local/bin/crc-check-cloud-env.sh
 ExecStart=/usr/local/bin/crc-cluster-status.sh
 RemainAfterExit=true

--- a/systemd/crc-cluster-status.sh
+++ b/systemd/crc-cluster-status.sh
@@ -4,39 +4,11 @@ set -x
 
 export KUBECONFIG=/opt/kubeconfig
 
-function check_cluster_healthy() {
-    WAIT="authentication|console|etcd|ingress|openshift-apiserver"
-
-    until `oc get co > /dev/null 2>&1`
-    do
-        sleep 2
-    done
-
-    for i in $(oc get co | grep -P "$WAIT" | awk '{ print $3 }')
-    do
-        if [[ $i == "False" ]]
-        then
-            return 1
-        fi
-    done
-    return 0
-}
-
 rm -rf /tmp/.crc-cluster-ready
 
-COUNTER=0
-CLUSTER_HEALTH_SLEEP=8
-CLUSTER_HEALTH_RETRIES=500
-
-while ! check_cluster_healthy
-do
-    sleep $CLUSTER_HEALTH_SLEEP
-    if [[ $COUNTER == $CLUSTER_HEALTH_RETRIES ]]
-    then
-        return 1
-    fi
-    ((COUNTER++))
-done
+if ! oc adm wait-for-stable-cluster --minimum-stable-period=3m --timeout=10m; then
+    exit 1
+fi
 
 # need to set a marker to let `crc` know the cluster is ready
 touch /tmp/.crc-cluster-ready

--- a/systemd/crc-pullsecret.service
+++ b/systemd/crc-pullsecret.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=CRC Unit for adding pull secret to cluster
-After=kubelet.service
+After=crc-wait-apiserver-up.service
 StartLimitIntervalSec=90sec
 
 [Service]

--- a/systemd/crc-pullsecret.service
+++ b/systemd/crc-pullsecret.service
@@ -1,11 +1,13 @@
 [Unit]
 Description=CRC Unit for adding pull secret to cluster
 After=crc-wait-apiserver-up.service
-StartLimitIntervalSec=90sec
+StartLimitIntervalSec=450
+StartLimitBurst=10
 
 [Service]
 Type=oneshot
 Restart=on-failure
+RestartSec=40
 ExecCondition=/usr/local/bin/crc-check-cloud-env.sh
 ExecStart=/usr/local/bin/crc-pullsecret.sh
 

--- a/systemd/crc-pullsecret.sh
+++ b/systemd/crc-pullsecret.sh
@@ -14,7 +14,7 @@ existingPs=$(echo "${existingPsB64}" | base64 -d)
 echo "${existingPs}" | jq -e '.auths'
 
 if [[ $? != 0 ]]; then
-    pullSecretB64=$(cat /opt/crc/pull-secret | base64 -w0)
+    pullSecretB64=$(base64 -w0 < /opt/crc/pull-secret)
     oc patch secret pull-secret -n openshift-config --type merge -p "{\"data\":{\".dockerconfigjson\":\"${pullSecretB64}\"}}"
 fi
 

--- a/systemd/crc-pullsecret.sh
+++ b/systemd/crc-pullsecret.sh
@@ -16,6 +16,5 @@ echo "${existingPs}" | jq -e '.auths'
 if [[ $? != 0 ]]; then
     pullSecretB64=$(cat /opt/crc/pull-secret | base64 -w0)
     oc patch secret pull-secret -n openshift-config --type merge -p "{\"data\":{\".dockerconfigjson\":\"${pullSecretB64}\"}}"
-    rm -f /opt/crc/pull-secret
 fi
 

--- a/systemd/crc-routes-controller.service
+++ b/systemd/crc-routes-controller.service
@@ -1,10 +1,13 @@
 [Unit]
 Description=CRC Unit starting routes controller
 After=crc-wait-apiserver-up.service
+StartLimitIntervalSec=450
+StartLimitBurst=10
 
 [Service]
 Type=oneshot
 Restart=on-failure
+RestartSec=40
 EnvironmentFile=-/etc/sysconfig/crc-env
 ExecCondition=/usr/local/bin/crc-check-cloud-env.sh
 ExecStart=/usr/local/bin/crc-routes-controller.sh

--- a/systemd/crc-routes-controller.service
+++ b/systemd/crc-routes-controller.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=CRC Unit starting routes controller
-After=kubelet.service
+After=crc-wait-apiserver-up.service
 
 [Service]
 Type=oneshot

--- a/systemd/crc-systemd-common.sh
+++ b/systemd/crc-systemd-common.sh
@@ -3,10 +3,11 @@
 function wait_for_resource() {
     local retry=0
     local max_retry=${2:-20}
+    local wait_sec=${3:-5}
     until `oc get "$1" > /dev/null 2>&1`
     do
         [ $retry == $max_retry ] && exit 1
-        sleep 5
+        sleep $wait_sec
         ((retry++))
     done
 }

--- a/systemd/crc-wait-apiserver-up.service
+++ b/systemd/crc-wait-apiserver-up.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=CRC Unit waiting till k8s API server is up
+Requires=kubelet.service
+After=kubelet.service
+Before=ocp-delete-mco-leases.service
+
+[Service]
+Type=oneshot
+Restart=on-failure
+ExecCondition=/usr/local/bin/crc-check-cloud-env.sh
+ExecStart=/usr/local/bin/crc-wait-apiserver-up.sh
+
+[Install]
+WantedBy=multi-user.target

--- a/systemd/crc-wait-apiserver-up.sh
+++ b/systemd/crc-wait-apiserver-up.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+set -x
+
+source /usr/local/bin/crc-systemd-common.sh
+export KUBECONFIG=/opt/kubeconfig
+
+# $1 resource, $2 retry count, $3 wait time
+wait_for_resource node 4 60

--- a/systemd/ocp-cluster-ca.service
+++ b/systemd/ocp-cluster-ca.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=CRC Unit setting custom cluster ca
-After=kubelet.service ocp-clusterid.service
+After=crc-wait-apiserver-up.service
 
 [Service]
 Type=oneshot

--- a/systemd/ocp-cluster-ca.service
+++ b/systemd/ocp-cluster-ca.service
@@ -1,10 +1,13 @@
 [Unit]
 Description=CRC Unit setting custom cluster ca
 After=crc-wait-apiserver-up.service
+StartLimitIntervalSec=450
+StartLimitBurst=10
 
 [Service]
 Type=oneshot
 Restart=on-failure
+RestartSec=40
 ExecCondition=/usr/local/bin/crc-check-cloud-env.sh
 ExecStart=/usr/local/bin/ocp-cluster-ca.sh
 

--- a/systemd/ocp-cluster-ca.sh
+++ b/systemd/ocp-cluster-ca.sh
@@ -33,8 +33,6 @@ oc patch apiserver cluster --type=merge -p '{"spec": {"clientCA": {"name": "clie
 oc create configmap admin-kubeconfig-client-ca -n openshift-config --from-file=ca-bundle.crt=${custom_ca_path} \
     --dry-run=client -o yaml | oc replace -f -
 
-rm -f /opt/crc/custom-ca.crt
-
 # create CSR
 openssl req -new -newkey rsa:4096 -nodes -keyout /tmp/newauth-access.key -out /tmp/newauth-access.csr -subj "/CN=system:admin"
 

--- a/systemd/ocp-cluster-ca.sh
+++ b/systemd/ocp-cluster-ca.sh
@@ -45,7 +45,7 @@ spec:
   signerName: kubernetes.io/kube-apiserver-client
   groups:
   - system:authenticated
-  request: $(cat /tmp/newauth-access.csr | base64 -w0)
+  request: $(base64 -w0 < /tmp/newauth-access.csr)
   usages:
   - client auth
 EOF

--- a/systemd/ocp-clusterid.service
+++ b/systemd/ocp-clusterid.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=CRC Unit setting random cluster ID
-After=kubelet.service
+After=crc-wait-apiserver-up.service
 
 [Service]
 Type=oneshot

--- a/systemd/ocp-clusterid.service
+++ b/systemd/ocp-clusterid.service
@@ -1,12 +1,15 @@
 [Unit]
 Description=CRC Unit setting random cluster ID
 After=crc-wait-apiserver-up.service
+StartLimitIntervalSec=450
+StartLimitBurst=10
 
 [Service]
 Type=oneshot
+Restart=on-failure
+RestartSec=40
 ExecCondition=/usr/local/bin/crc-check-cloud-env.sh
 ExecStart=/usr/local/bin/ocp-clusterid.sh
-Restart=on-failure
 
 [Install]
 WantedBy=multi-user.target

--- a/systemd/ocp-custom-domain.service
+++ b/systemd/ocp-custom-domain.service
@@ -1,10 +1,13 @@
 [Unit]
 Description=CRC Unit setting nip.io domain for cluster
 After=crc-wait-apiserver-up.service
+StartLimitIntervalSec=450
+StartLimitBurst=10
 
 [Service]
 Type=oneshot
 Restart=on-failure
+RestartSec=40
 EnvironmentFile=-/etc/sysconfig/crc-env
 ExecCondition=/usr/local/bin/crc-check-cloud-env.sh
 ExecStart=/usr/local/bin/ocp-custom-domain.sh

--- a/systemd/ocp-custom-domain.service
+++ b/systemd/ocp-custom-domain.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=CRC Unit setting nip.io domain for cluster
-After=kubelet.service ocp-clusterid.service ocp-cluster-ca.service
+After=crc-wait-apiserver-up.service
 
 [Service]
 Type=oneshot

--- a/systemd/ocp-mco-sshkey.service
+++ b/systemd/ocp-mco-sshkey.service
@@ -1,12 +1,13 @@
 [Unit]
 Description=CRC Unit patching the MachineConfig to add new ssh key
 After=crc-wait-apiserver-up.service
-StartLimitIntervalSec=1min
-StartLimitBurst=1
+StartLimitIntervalSec=450
+StartLimitBurst=10
 
 [Service]
 Type=oneshot
 Restart=on-failure
+RestartSec=40
 ExecCondition=/usr/local/bin/crc-check-cloud-env.sh
 ExecStart=/usr/local/bin/ocp-mco-sshkey.sh
 RemainAfterExit=true

--- a/systemd/ocp-mco-sshkey.service
+++ b/systemd/ocp-mco-sshkey.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=CRC Unit patching the MachineConfig to add new ssh key
-After=kubelet.service
+After=crc-wait-apiserver-up.service
 StartLimitIntervalSec=1min
 StartLimitBurst=1
 

--- a/systemd/ocp-mco-sshkey.sh
+++ b/systemd/ocp-mco-sshkey.sh
@@ -15,5 +15,8 @@ fi
 echo "Updating the public key resource for machine config operator"
 pub_key=$(tr -d '\n\r' < ${pub_key_path})
 wait_for_resource machineconfig
-oc patch machineconfig 99-master-ssh -p "{\"spec\": {\"config\": {\"passwd\": {\"users\": [{\"name\": \"core\", \"sshAuthorizedKeys\": [\"${pub_key}\"]}]}}}}" --type merge
-[ "$?" != 0 ] && echo "failed to update public key to machine config operator" && exit 1
+if ! oc patch machineconfig 99-master-ssh -p "{\"spec\": {\"config\": {\"passwd\": {\"users\": [{\"name\": \"core\", \"sshAuthorizedKeys\": [\"${pub_key}\"]}]}}}}" --type merge;
+then
+    echo "failed to update public key to machine config operator"
+    exit 1
+fi

--- a/systemd/ocp-userpasswords.service
+++ b/systemd/ocp-userpasswords.service
@@ -1,10 +1,13 @@
 [Unit]
 Description=CRC Unit setting the developer and kubeadmin user password
 After=crc-wait-apiserver-up.service
+StartLimitIntervalSec=450
+StartLimitBurst=10
 
 [Service]
 Type=oneshot
 Restart=on-failure
+RestartSec=40
 ExecCondition=/usr/local/bin/crc-check-cloud-env.sh
 ExecStartPre=/usr/bin/sleep 5
 ExecStart=/usr/local/bin/ocp-userpasswords.sh

--- a/systemd/ocp-userpasswords.service
+++ b/systemd/ocp-userpasswords.service
@@ -1,5 +1,6 @@
 [Unit]
 Description=CRC Unit setting the developer and kubeadmin user password
+Before=ocp-cluster-ca.service
 After=crc-wait-apiserver-up.service
 StartLimitIntervalSec=450
 StartLimitBurst=10

--- a/systemd/ocp-userpasswords.service
+++ b/systemd/ocp-userpasswords.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=CRC Unit setting the developer and kubeadmin user password
-After=kubelet.service
+After=crc-wait-apiserver-up.service
 
 [Service]
 Type=oneshot


### PR DESCRIPTION
this adds systemd services to perform the following tasks:
- service that waits for api server to become available
  (this will help to schedule other services after this)
- service to delete MCO leader leases
- service to check if pull-secret was written to disk

## Summary by Sourcery

Add missing systemd services and enhance the common helper script to support a fully self-sufficient bundle by waiting for the API server, cleaning up MCO leases, and ensuring the pull-secret is written to disk.

New Features:
- Add systemd service to wait for the API server to become available
- Add systemd service to delete machine-config-operator leader leases
- Add systemd service to verify the pull-secret file is present on disk

Enhancements:
- Parameterize the wait interval in the common wait_for_resource helper function