### PR TITLE
add mechanism to cache the coreos iso

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,9 @@ EOF
 export OKD_VERSION=4.5.0-0.okd-2020-08-12-020541
 export OPENSHIFT_PULL_SECRET_PATH="/tmp/pull_secret.json"
 
+# Optionally cache the iso somewhere
+export ISO_CACHE_DIR=$HOME/.local/share/libvirt/images
+
 # Build the Single Node cluster
 ./snc.sh
 ```


### PR DESCRIPTION
Downloading this on every run gets tedious.

Also, since we're already here, get the link and sha256 from json using jq.

## Summary by Sourcery

Introduce a configurable cache for the CoreOS ISO in snc.sh to avoid repeated downloads by parsing download URL and checksum via jq and only re-downloading when necessary.

New Features:
- Add a mechanism to cache the CoreOS ISO in a customizable directory to speed up repeated runs.

Enhancements:
- Switch ISO URL and checksum extraction to use jq on the installer’s JSON output.
- Download the ISO only if it’s missing or its SHA256 doesn’t match the cached copy.

Documentation:
- Document the optional ISO_CACHE_DIR environment variable in the README.