### PR TITLE
Issue 1097 misc changes for custom rhcos image and /Users directory

### DIFF
--- a/snc.sh
+++ b/snc.sh
@@ -335,4 +335,7 @@ ${SSH} core@api.${SNC_PRODUCT_NAME}.${BASE_DOMAIN} -- 'sudo crictl rmi --prune'
 # Remove the baremetal_runtimecfg container which is temp created
 ${SSH} core@api.${SNC_PRODUCT_NAME}.${BASE_DOMAIN} -- "sudo podman rm baremetal_runtimecfg"
 
+# Remove the image stream of custom image
+retry ${OC} delete imagestream rhcos -n openshift-machine-config-operator
+retry ${OC} adm prune images --confirm --registry-url default-route-openshift-image-registry.apps-crc.testing
 

--- a/snc.sh
+++ b/snc.sh
@@ -283,7 +283,7 @@ EOF
 podman build --from ${RHCOS_IMAGE} --authfile ${OPENSHIFT_PULL_SECRET_PATH} -t default-route-openshift-image-registry.apps-crc.testing/openshift-machine-config-operator/rhcos:latest --file ${INSTALL_DIR}/Containerfile .
 retry ${OC} login -u kubeadmin -p $(cat ${INSTALL_DIR}/auth/kubeadmin-password) --insecure-skip-tls-verify=true api.${SNC_PRODUCT_NAME}.${BASE_DOMAIN}:6443
 retry ${OC} registry login -a ${INSTALL_DIR}/reg.json
-podman push --authfile ${INSTALL_DIR}/reg.json --tls-verify=false default-route-openshift-image-registry.apps-crc.testing/openshift-machine-config-operator/rhcos:latest
+retry podman push --authfile ${INSTALL_DIR}/reg.json --tls-verify=false default-route-openshift-image-registry.apps-crc.testing/openshift-machine-config-operator/rhcos:latest
 cat << EOF > ${INSTALL_DIR}/custom-os-mc.yaml
 apiVersion: machineconfiguration.openshift.io/v1
 kind: MachineConfig

--- a/snc.sh
+++ b/snc.sh
@@ -335,6 +335,10 @@ ${SSH} core@api.${SNC_PRODUCT_NAME}.${BASE_DOMAIN} -- 'sudo crictl rmi --prune'
 # Remove the baremetal_runtimecfg container which is temp created
 ${SSH} core@api.${SNC_PRODUCT_NAME}.${BASE_DOMAIN} -- "sudo podman rm baremetal_runtimecfg"
 
+# Create the /var/Users directory so it can become writeable
+# todo: remove it once custom image able to perform it
+${SSH} core@api.${SNC_PRODUCT_NAME}.${BASE_DOMAIN} -- 'sudo mkdir /var/Users'
+
 # Check /Users directory is writeable
 ${SSH} core@api.${SNC_PRODUCT_NAME}.${BASE_DOMAIN} -- 'sudo mkdir /Users/foo && sudo rm -fr /Users/foo'
 

--- a/snc.sh
+++ b/snc.sh
@@ -266,9 +266,9 @@ wait_till_cluster_stable
 # This section is used to create a custom-os image which have `/Users`
 # For more details check https://github.com/crc-org/snc/issues/1041#issuecomment-2785928976
 # This should be performed before removing pull secret
-# Unsetting KUBECONFIG is required because it has default `system:admin` user which doesn't able to create
+# Set tmp KUBECONFIG because default kubeconfig have `system:admin` user which doesn't able to create
 # token to login to registry and kubeadmin user is required for that.
-unset KUBECONFIG
+export KUBECONFIG=/tmp/kubeconfig
 if [[ ${BUNDLE_TYPE} == "okd" ]]; then
      RHCOS_IMAGE=$(${OC} adm release info -a ${OPENSHIFT_PULL_SECRET_PATH} ${OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE} --image-for=stream-coreos)
 else
@@ -299,7 +299,6 @@ while retry ${OC} get mcp master -ojsonpath='{.status.conditions[?(@.type!="Upda
     echo "Machine config still in updating/degrading state"
 done
 
-export KUBECONFIG=${INSTALL_DIR}/auth/kubeconfig
 mc_before_removing_pullsecret=$(retry ${OC} get mc --sort-by=.metadata.creationTimestamp --no-headers -oname)
 # Replace pull secret with a null json string '{}'
 retry ${OC} replace -f pull-secret.yaml

--- a/snc.sh
+++ b/snc.sh
@@ -227,10 +227,8 @@ retry ${OC} scale --replicas=1 ingresscontroller/default -n openshift-ingress-op
 
 # Set managementState Image Registry Operator configuration from Removed to Managed
 # because https://docs.openshift.com/container-platform/latest/registry/configuring_registry_storage/configuring-registry-storage-baremetal.html#registry-removed_configuring-registry-storage-baremetal
-retry ${OC} patch config.imageregistry.operator.openshift.io/cluster --patch '{"spec":{"managementState":"Managed"}}' --type=merge
-
 # Set default route for registry CRD from false to true.
-retry ${OC} patch config.imageregistry.operator.openshift.io/cluster --patch '{"spec":{"defaultRoute":true}}' --type=merge
+retry ${OC} patch config.imageregistry.operator.openshift.io/cluster --patch '{"spec":{"managementState":"Managed","defaultRoute":true}}' --type=merge
 
 # Generate the htpasswd file to have admin and developer user
 generate_htpasswd_file ${INSTALL_DIR} ${HTPASSWD_FILE}

--- a/snc.sh
+++ b/snc.sh
@@ -335,6 +335,9 @@ ${SSH} core@api.${SNC_PRODUCT_NAME}.${BASE_DOMAIN} -- 'sudo crictl rmi --prune'
 # Remove the baremetal_runtimecfg container which is temp created
 ${SSH} core@api.${SNC_PRODUCT_NAME}.${BASE_DOMAIN} -- "sudo podman rm baremetal_runtimecfg"
 
+# Check /Users directory is writeable
+${SSH} core@api.${SNC_PRODUCT_NAME}.${BASE_DOMAIN} -- 'sudo mkdir /Users/foo && sudo rm -fr /Users/foo'
+
 # Remove the image stream of custom image
 retry ${OC} delete imagestream rhcos -n openshift-machine-config-operator
 retry ${OC} adm prune images --confirm --registry-url default-route-openshift-image-registry.apps-crc.testing

--- a/snc.sh
+++ b/snc.sh
@@ -69,7 +69,7 @@ echo "Setting OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE to ${OPENSHIFT_INSTALL_RE
 # Extract openshift-install binary if not present in current directory
 if test -z ${OPENSHIFT_INSTALL-}; then
     OPENSHIFT_INSTALL=./openshift-install
-    if [[ ! -f "$OPENSHIFT_INSTALL" || $("$OPENSHIFT_INSTALL" version | grep -oP "${OPENSHIFT_INSTALL} \\K\\S+") != "$OPENSHIFT_VERSION" ]]; then
+    if [[ ! -f "$OPENSHIFT_INSTALL" || $("$OPENSHIFT_INSTALL" version | grep -oP "${OPENSHIFT_INSTALL} \\K\\S+") != "$OPENSHIFT_RELEASE_VERSION" ]]; then
         echo "Extracting OpenShift installer binary"
         ${OC} adm release extract -a ${OPENSHIFT_PULL_SECRET_PATH} ${OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE} --command=openshift-install --to .
     fi

--- a/tools.sh
+++ b/tools.sh
@@ -196,7 +196,7 @@ function create_vm {
     local iso=$1
 
     bootOption=""
-    if ${BUNDLE_TYPE} != "okd"; then
+    if [[ ${BUNDLE_TYPE} != "okd" ]]; then
         bootOption="--boot uefi"
     fi
 


### PR DESCRIPTION
-  Add retry for podman push to internal registry
-  Remove modified rhcos image from internal registry
-  Add a check to verify /Users directory is writeable

## Summary by Sourcery

Add reliability to internal registry operations, verify remote directory permissions, and clean up custom RHCOS image artifacts.

Enhancements:
- Wrap the Podman push to the internal registry with a retry mechanism.
- Add a remote check to ensure the /Users directory on the core node is writable.
- Delete the custom RHCOS imagestream and prune the internal registry of obsolete images.