### PR TITLE
microshift: update bootc image to RHEL-9.6 from RHEL-9.4

### DIFF
--- a/image-mode/microshift/config/Containerfile.bootc-rhel9
+++ b/image-mode/microshift/config/Containerfile.bootc-rhel9
@@ -1,4 +1,4 @@
-FROM registry.redhat.io/rhel9/rhel-bootc:9.4
+FROM registry.redhat.io/rhel9/rhel-bootc:9.6
 
 ARG MICROSHIFT_VER=4.18
 RUN if [ -z "${UNRELEASED_MIRROR_REPO}" ]; then \


### PR DESCRIPTION
## Summary by Sourcery

Build:
- Bump the RHEL base image tag in Containerfile.bootc-rhel9 from 9.4 to 9.6