### PR TITLE
gvforwarder: Remove ExecStartPre from systemd unit

### DIFF
--- a/createdisk.sh
+++ b/createdisk.sh
@@ -114,7 +114,6 @@ After=sys-devices-virtual-net-%i.device
 Restart=on-failure
 Environment="GV_VSOCK_PORT=1024"
 EnvironmentFile=-/etc/sysconfig/gv-user-network
-ExecStartPre=/bin/sh -c 'for i in {1..10}; do ip link show "\\\$1" && exit 0; sleep 1; done; exit 1' _ %i
 ExecStart=/usr/libexec/podman/gvforwarder -preexisting -iface %i -url vsock://2:"\\\${GV_VSOCK_PORT}"/connect
 
 [Install]


### PR DESCRIPTION
The loop waiting for the network device is redundant with
`After=sys-devices-virtual-net-%i.device`

## Summary by Sourcery

Enhancements:
- Remove redundant ExecStartPre network-wait loop from the gvforwarder systemd unit