### PR TITLE
Fix ci image

### DIFF
--- a/images/openshift-ci/Dockerfile
+++ b/images/openshift-ci/Dockerfile
@@ -4,7 +4,7 @@ FROM scratch AS builder
 WORKDIR /code-ready/snc
 COPY . .
 
-FROM centos:8
+FROM registry.access.redhat.com/ubi9/ubi
 COPY --from=builder /code-ready/snc /opt/snc
 COPY --from=builder /code-ready/snc/images/openshift-ci/mock-nss.sh /bin/mock-nss.sh
 COPY --from=builder /code-ready/snc/images/openshift-ci/google-cloud-sdk.repo /etc/yum.repos.d/google-cloud-sdk.repo

--- a/images/openshift-ci/Dockerfile
+++ b/images/openshift-ci/Dockerfile
@@ -12,7 +12,7 @@ COPY --from=builder /code-ready/snc/images/openshift-ci/google-cloud-sdk.repo /e
 RUN yum update -y && \
     yum install --setopt=tsflags=nodocs -y \
     gettext \
-    google-cloud-sdk-365.0.1 \
+    google-cloud-cli \
     nss_wrapper \
     openssh-clients && \
     yum clean all && rm -rf /var/cache/yum/*

--- a/images/openshift-ci/google-cloud-sdk.repo
+++ b/images/openshift-ci/google-cloud-sdk.repo
@@ -1,8 +1,7 @@
 [google-cloud-sdk]
 name=Google Cloud SDK
-baseurl=https://packages.cloud.google.com/yum/repos/cloud-sdk-el8-x86_64
+baseurl=https://packages.cloud.google.com/yum/repos/cloud-sdk-el9-x86_64
 enabled=1
 gpgcheck=1
-repo_gpgcheck=1
-gpgkey=https://packages.cloud.google.com/yum/doc/yum-key.gpg
-       https://packages.cloud.google.com/yum/doc/rpm-package-key.gpg
+repo_gpgcheck=0
+gpgkey=https://packages.cloud.google.com/yum/doc/rpm-package-key.gpg


### PR DESCRIPTION
- Update image to ub19
- update gcloud repo details.

## Summary by Sourcery

Rebase the OpenShift CI Docker image on Red Hat UBI9 and update the Google Cloud SDK installation

Enhancements:
- Replace CentOS 8 base image with registry.access.redhat.com/ubi9/ubi

Build:
- Switch the installed Google Cloud SDK package from a fixed version to google-cloud-cli

CI:
- Refresh Google Cloud SDK repository configuration in the CI image