### PR TITLE
snc: Add --keep-younger-than=0s to remove rhcos custom image

### DIFF
--- a/snc.sh
+++ b/snc.sh
@@ -341,5 +341,5 @@ ${SSH} core@api.${SNC_PRODUCT_NAME}.${BASE_DOMAIN} -- 'sudo mkdir /Users/foo && 
 
 # Remove the image stream of custom image
 retry ${OC} delete imagestream rhcos -n openshift-machine-config-operator
-retry ${OC} adm prune images --confirm --registry-url default-route-openshift-image-registry.apps-crc.testing
+retry ${OC} adm prune images --confirm --registry-url default-route-openshift-image-registry.apps-crc.testing --keep-younger-than=0s
 


### PR DESCRIPTION
As per `oc adm prune images` help section looks like even unused images can't be removed if it is recently created and have default time 60 mins. This pr change that to 0s so that custom image is pruned from internal registry and not increase the bundle size.

```
--keep-younger-than=1h0m0s:
	Specify the minimum age of an image and its referrers for it to be considered a candidate for pruning.
```

## Summary by Sourcery

Enhancements:
- Add --keep-younger-than=0s flag to oc adm prune images to remove recently created images

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated image pruning process to remove all images regardless of age in the OpenShift internal registry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->