### PR TITLE
createdisk: Remove the fedora-updates repo after install qemu-user-static

### DIFF
--- a/createdisk.sh
+++ b/createdisk.sh
@@ -158,6 +158,7 @@ EOF
    ${SCP} /tmp/fedora-updates.repo core@${VM_IP}:/tmp
    ${SSH} core@${VM_IP} -- "sudo mv /tmp/fedora-updates.repo /etc/yum.repos.d"
    ${SSH} core@${VM_IP} -- "sudo rpm-ostree install qemu-user-static-x86"
+   ${SSH} core@${VM_IP} -- "sudo rm -fr /etc/yum.repos.d/fedora-updates.repo"
 fi
 
 # Beyond this point, packages added to the ADDITIONAL_PACKAGES variable won’t be installed in the guest


### PR DESCRIPTION
If we don't remove that, it going to use for other packages instead of getting it from rhel side.

Recently with ocp bundle for arm64 we found that this repo caused issue for gvisor rpms.

```
$ rpm -qa | grep gvisor
gvisor-tap-vsock-gvforwarder-0.8.5-1.fc41.aarch64
gvisor-tap-vsock-0.8.5-1.fc41.aarch64
```

## Summary by Sourcery

Bug Fixes:
- Remove the fedora-updates repository after installing qemu-user-static to avoid packages being sourced from Fedora instead of RHEL

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Temporary Fedora updates repository file is now automatically removed from the guest VM after installing required packages for certain configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->