### PR TITLE
createdisk: download qemu-static package instead install

### DIFF
--- a/createdisk.sh
+++ b/createdisk.sh
@@ -157,8 +157,9 @@ gpgcheck=0
 EOF
    ${SCP} /tmp/fedora-updates.repo core@${VM_IP}:/tmp
    ${SSH} core@${VM_IP} -- "sudo mv /tmp/fedora-updates.repo /etc/yum.repos.d"
-   ${SSH} core@${VM_IP} -- "sudo rpm-ostree install qemu-user-static-x86"
+   ${SSH} core@${VM_IP} -- "mkdir -p ~/packages && dnf download --downloadonly --downloaddir ~/packages qemu-user-static-x86 --resolve"
    ${SSH} core@${VM_IP} -- "sudo rm -fr /etc/yum.repos.d/fedora-updates.repo"
+   ADDITIONAL_PACKAGES+=" qemu-user-static-x86"
 fi
 
 # Beyond this point, packages added to the ADDITIONAL_PACKAGES variable won’t be installed in the guest


### PR DESCRIPTION
This pr downloads the qemu-static package from the fedora repo and put it to `packages` dir instead installing it because if we install and then remove the fedora repo which is done  as part of 2dbbc98038db922ca9eb3885f468fd8430717a86 commit then it create a deployment layer for rpm-ostree. Now when we try to install other packages it is going to again check if `qemu-static` package available because rpm-ostree requires all previously layered packages to still be resolvable when you install new ones. If any of them are missing (like qemu-user-static-x86), the operation fails with following error.

This PR try to solve  it by not installing but just download it and adding this package as part of additional_packages variable so that it can be part of local repo and install without error.

```
 + ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i id_ecdsa_crc core@192.168.126.11 -- 'sudo rpm-ostree install cloud-init gvisor-tap-vsock-gvforwarder'
Warning: Permanently added '192.168.126.11' (ED25519) to the list of known hosts.
Checking out tree 70544e8...done
Enabled rpm-md repositories: local
Importing rpm-md...done
rpm-md repo 'local' (cached); generated: 2025-06-30T17:16:37Z solvables: 173
error: Packages not found: qemu-user-static-x
```

## Summary by Sourcery

Use `dnf download` to fetch qemu-user-static-x86 into the local `packages` directory and add it to `ADDITIONAL_PACKAGES` instead of installing via `rpm-ostree` to avoid residual layered package errors after removing the Fedora repo.

Enhancements:
- Download qemu-user-static-x86 to a local `packages` directory rather than installing it directly.
- Append qemu-user-static-x86 to the `ADDITIONAL_PACKAGES` list for inclusion in the local repository.
- Retain and remove the Fedora updates repository around the download step to prevent orphaned rpm-ostree layers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Changed package handling on aarch64 VMs by downloading required packages for later installation instead of installing them immediately. This affects the setup process for certain architectures and bundle types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->