### PR TITLE
createdisk: Add cloud-utils-growpart package

### DIFF
--- a/createdisk.sh
+++ b/createdisk.sh
@@ -16,7 +16,7 @@ INSTALL_DIR=${1:-crc-tmp-install-data}
 OPENSHIFT_VERSION=$(${JQ} -r .clusterInfo.openshiftVersion $INSTALL_DIR/crc-bundle-info.json)
 BASE_DOMAIN=$(${JQ} -r .clusterInfo.baseDomain $INSTALL_DIR/crc-bundle-info.json)
 BUNDLE_TYPE=$(${JQ} -r .type $INSTALL_DIR/crc-bundle-info.json)
-ADDITIONAL_PACKAGES="cloud-init gvisor-tap-vsock-gvforwarder"
+ADDITIONAL_PACKAGES="cloud-init gvisor-tap-vsock-gvforwarder cloud-utils-growpart"
 
 case ${BUNDLE_TYPE} in
     microshift)

--- a/image-mode/microshift/config/Containerfile.bootc-rhel9
+++ b/image-mode/microshift/config/Containerfile.bootc-rhel9
@@ -14,7 +14,7 @@ RUN if [ -z "${UNRELEASED_MIRROR_REPO}" ]; then \
           --set-enabled "fast-datapath-for-rhel-9-$(uname -m)-rpms"; \
       dnf config-manager --save --setopt="${repoID}".gpgcheck=0 --setopt=*-el9-beta.gpgcheck=0; \
     fi
-RUN dnf install -y firewalld microshift microshift-release-info cloud-utils-growpart qemu-guest-agent dnsmasq && \
+RUN dnf install -y firewalld microshift microshift-release-info qemu-guest-agent dnsmasq && \
     dnf clean all && rm -fr /etc/yum.repos.d/*
 
 # https://github.com/containers/bootc/discussions/1036


### PR DESCRIPTION
This package provides the growpart script for growing a partition. It is primarily used in cloud images in conjunction with the dracut-modules-growroot package to grow the root partition on first boot. It suppose to solve the issue for cloud deployment of crc using mapt when specify disk size bigger than default size(30G) by auto resize the disk.

- https://github.com/canonical/cloud-utils/

mapt issue: https://github.com/redhat-developer/mapt/issues/524

## Summary by Sourcery

New Features:
- Add cloud-utils-growpart to the list of additional packages for automatic root partition expansion on boot.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the disk creation process to include an additional package for enhanced guest VM image capabilities.
  * Adjusted container image package installation to optimize included components.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->