### PR TITLE
Introduce PRE_DOWNLOADED_ADDITIONAL_PACKAGES variable

### DIFF
--- a/createdisk-library.sh
+++ b/createdisk-library.sh
@@ -202,7 +202,7 @@ enabled=1
 gpgcheck=0
 EOF'"
         # Install these rpms to VM
-        ${SSH} core@${vm_ip} -- "sudo rpm-ostree install $ADDITIONAL_PACKAGES"
+        ${SSH} core@${vm_ip} -- "sudo rpm-ostree install $ADDITIONAL_PACKAGES $PRE_DOWNLOADED_ADDITIONAL_PACKAGES"
 
         # Remove the packages and repo from VM
         ${SSH} core@${vm_ip} -- sudo rm -fr /home/core/packages

--- a/createdisk.sh
+++ b/createdisk.sh
@@ -17,6 +17,7 @@ OPENSHIFT_VERSION=$(${JQ} -r .clusterInfo.openshiftVersion $INSTALL_DIR/crc-bund
 BASE_DOMAIN=$(${JQ} -r .clusterInfo.baseDomain $INSTALL_DIR/crc-bundle-info.json)
 BUNDLE_TYPE=$(${JQ} -r .type $INSTALL_DIR/crc-bundle-info.json)
 ADDITIONAL_PACKAGES="cloud-init gvisor-tap-vsock-gvforwarder"
+PRE_DOWNLOADED_ADDITIONAL_PACKAGES=""
 
 case ${BUNDLE_TYPE} in
     microshift)
@@ -159,7 +160,7 @@ EOF
    ${SSH} core@${VM_IP} -- "sudo mv /tmp/fedora-updates.repo /etc/yum.repos.d"
    ${SSH} core@${VM_IP} -- "mkdir -p ~/packages && dnf download --downloadonly --downloaddir ~/packages qemu-user-static-x86 --resolve"
    ${SSH} core@${VM_IP} -- "sudo rm -fr /etc/yum.repos.d/fedora-updates.repo"
-   ADDITIONAL_PACKAGES+=" qemu-user-static-x86"
+   PRE_DOWNLOADED_ADDITIONAL_PACKAGES+=" qemu-user-static-x86"
 fi
 
 # Beyond this point, packages added to the ADDITIONAL_PACKAGES variable won’t be installed in the guest


### PR DESCRIPTION
Having only ADDITIONAL_PACKAGES variable and then adding the packages to it which are already downloaded because those comes from different repo makes the whole installation of additional packages logic break because in that logic we first download those additional packages using yum download then then create local repo and finally push it to VM for installation. Since some packages like qemu-user-static is comes from fedora repo and we just can't enable this because it might affect other packages and we hit situation like https://github.com/crc-org/snc/commit/718a9c4f9c3e65128a2d0c4f707e3c109a3182db one.

So this PR separate addtional packages which can be downloaded from official repo to other packages which comes from different repo but at the installation time it should be creating single layer on ostree side.

## Summary by Sourcery

Introduce PRE_DOWNLOAD_ADDITIONAL_PACKAGES to separate packages that require pre-download from external repos and include them during the rpm-ostree installation in a single layer.

Enhancements:
- Add PRE_DOWNLOAD_ADDITIONAL_PACKAGES variable to track pre-downloaded external packages
- Include PRE_DOWNLOAD_ADDITIONAL_PACKAGES in the rpm-ostree install command alongside ADDITIONAL_PACKAGES

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved handling of additional package installation by introducing a separate variable for pre-downloaded packages.
  * Adjusted package assignment for specific architectures to ensure correct packages are installed or pre-downloaded as intended.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->