### PR TITLE
Fix unit target for crc/ocp service

### DIFF
--- a/createdisk-library.sh
+++ b/createdisk-library.sh
@@ -409,6 +409,7 @@ function copy_systemd_units() {
 
     ${SSH} core@${VM_IP} -- 'mkdir -p /home/core/systemd-units && mkdir -p /home/core/systemd-scripts'
     ${SCP} systemd/crc-*.service core@${VM_IP}:/home/core/systemd-units/
+    ${SCP} systemd/crc-*.target core@${VM_IP}:/home/core/systemd-units/
     ${SCP} systemd/crc-*.sh core@${VM_IP}:/home/core/systemd-scripts/
 
     case "${BUNDLE_TYPE}" in

--- a/createdisk.sh
+++ b/createdisk.sh
@@ -114,6 +114,7 @@ After=sys-devices-virtual-net-%i.device
 Restart=on-failure
 Environment="GV_VSOCK_PORT=1024"
 EnvironmentFile=-/etc/sysconfig/gv-user-network
+ExecCondition=/bin/sh -c '! /usr/local/bin/crc-check-cloud-env.sh'
 ExecStartPre=/bin/sh -c 'for i in {1..10}; do ip link show "\\\$1" && exit 0; sleep 1; done; exit 1' _ %i
 ExecStart=/usr/libexec/podman/gvforwarder -preexisting -iface %i -url vsock://2:"\\\${GV_VSOCK_PORT}"/connect
 

--- a/systemd/crc-cluster-status.service
+++ b/systemd/crc-cluster-status.service
@@ -16,4 +16,4 @@ ExecStart=/usr/local/bin/crc-cluster-status.sh
 RemainAfterExit=true
 
 [Install]
-WantedBy=multi-user.target
+WantedBy=crc-custom.target

--- a/systemd/crc-custom.target
+++ b/systemd/crc-custom.target
@@ -1,0 +1,4 @@
+[Unit]
+Description=crc custom target
+Requires=kubelet-dependencies.target
+After=kubelet-dependencies.target

--- a/systemd/crc-pullsecret.service
+++ b/systemd/crc-pullsecret.service
@@ -14,4 +14,4 @@ ExecStart=/usr/local/bin/crc-pullsecret.sh
 ExecStartPost=-touch /opt/crc/%n.done
 
 [Install]
-WantedBy=multi-user.target
+WantedBy=crc-custom.target

--- a/systemd/crc-routes-controller.service
+++ b/systemd/crc-routes-controller.service
@@ -13,4 +13,4 @@ ExecCondition=/usr/local/bin/crc-check-cloud-env.sh
 ExecStart=/usr/local/bin/crc-routes-controller.sh
 
 [Install]
-WantedBy=multi-user.target
+WantedBy=crc-custom.target

--- a/systemd/crc-wait-apiserver-up.service
+++ b/systemd/crc-wait-apiserver-up.service
@@ -11,4 +11,4 @@ ExecCondition=/usr/local/bin/crc-check-cloud-env.sh
 ExecStart=/usr/local/bin/crc-wait-apiserver-up.sh
 
 [Install]
-WantedBy=multi-user.target
+WantedBy=crc-custom.target

--- a/systemd/ocp-cluster-ca.service
+++ b/systemd/ocp-cluster-ca.service
@@ -14,4 +14,4 @@ ExecStart=/usr/local/bin/ocp-cluster-ca.sh
 ExecStartPost=-touch /opt/crc/%n.done
 
 [Install]
-WantedBy=multi-user.target
+WantedBy=crc-custom.target

--- a/systemd/ocp-cluster-ca.sh
+++ b/systemd/ocp-cluster-ca.sh
@@ -65,7 +65,7 @@ oc config set-cluster "${cluster_name}" --server="${apiserver_url}" --insecure-s
 COUNTER=0
 until oc get co --context system:admin --kubeconfig="${updated_kubeconfig_path}";
 do
-    if [ $COUNTER == 30 ]; then
+    if [ $COUNTER == 90 ]; then
         echo "Unable to access API server using new client certitificate..."
         exit 1
     fi

--- a/systemd/ocp-clusterid.service
+++ b/systemd/ocp-clusterid.service
@@ -12,4 +12,4 @@ ExecCondition=/usr/local/bin/crc-check-cloud-env.sh
 ExecStart=/usr/local/bin/ocp-clusterid.sh
 
 [Install]
-WantedBy=multi-user.target
+WantedBy=crc-custom.target

--- a/systemd/ocp-custom-domain.service
+++ b/systemd/ocp-custom-domain.service
@@ -15,4 +15,4 @@ ExecStart=/usr/local/bin/ocp-custom-domain.sh
 ExecStartPost=-touch /opt/crc/%n.done
 
 [Install]
-WantedBy=multi-user.target
+WantedBy=crc-custom.target

--- a/systemd/ocp-growfs.service
+++ b/systemd/ocp-growfs.service
@@ -1,5 +1,6 @@
 [Unit]
 Description=CRC Unit to grow the root filesystem
+Requires=crc-custom.target
 
 [Service]
 Type=oneshot

--- a/systemd/ocp-mco-sshkey.service
+++ b/systemd/ocp-mco-sshkey.service
@@ -13,4 +13,4 @@ ExecStart=/usr/local/bin/ocp-mco-sshkey.sh
 RemainAfterExit=true
 
 [Install]
-WantedBy=multi-user.target
+WantedBy=crc-custom.target

--- a/systemd/ocp-userpasswords.service
+++ b/systemd/ocp-userpasswords.service
@@ -16,4 +16,4 @@ ExecStart=/usr/local/bin/ocp-userpasswords.sh
 ExecStartPost=-touch /opt/crc/%n.done
 
 [Install]
-WantedBy=multi-user.target
+WantedBy=crc-custom.target


### PR DESCRIPTION
This makes sure services are not depend on multi-user target and
cloud-final service able to run in time because as of now all our
services are making multi-user target to wait and indirectly cloud-final
service was also waiting. with this we get following dep graph
```
$ systemctl list-dependencies crc-custom.target
crc-custom.target
● ├─crc-cluster-status.service
○ ├─crc-pullsecret.service
○ ├─crc-routes-controller.service
○ ├─crc-wait-apiserver-up.service
○ ├─ocp-cluster-ca.service
○ ├─ocp-clusterid.service
○ ├─ocp-custom-domain.service
● ├─ocp-mco-sshkey.service
○ ├─ocp-userpasswords.service
● └─kubelet-dependencies.target
●   ├─chrony-wait.service
[---]
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a new custom systemd target for managing service startup order.

* **Chores**
  * Updated multiple services to use the new custom systemd target instead of the default target, improving control over service activation.
  * Added a dependency to ensure certain services are activated alongside the new custom target.
  * Enhanced deployment scripts to copy custom systemd target files to the VM for consistent service management.
  * Added a startup condition to a network service to verify environment suitability before activation.
  * Increased retry attempts for cluster API server readiness checks to improve robustness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->