### PR TITLE
CI: Update golang container image to use 1.24

### DIFF
--- a/ci.sh
+++ b/ci.sh
@@ -58,7 +58,7 @@ sudo systemctl reload NetworkManager
 
 git clone https://github.com/code-ready/crc.git
 pushd crc
-podman run --rm -v ${PWD}:/data:Z registry.ci.openshift.org/openshift/release:rhel-8-release-golang-1.23-openshift-4.19 /bin/bash -c "cd /data && make cross"
+podman run --rm -v ${PWD}:/data:Z registry.ci.openshift.org/openshift/release:rhel-9-release-golang-1.24-openshift-4.20 /bin/bash -c "cd /data && make cross"
 sudo mv out/linux-amd64/crc /usr/local/bin/
 popd
 

--- a/ci_microshift.sh
+++ b/ci_microshift.sh
@@ -18,7 +18,7 @@ sudo virsh undefine crc --nvram
 
 git clone https://github.com/crc-org/crc.git
 pushd crc
-podman run --rm -v ${PWD}:/data:Z registry.ci.openshift.org/openshift/release:rhel-8-release-golang-1.23-openshift-4.19 /bin/bash -c "cd /data && make cross"
+podman run --rm -v ${PWD}:/data:Z registry.ci.openshift.org/openshift/release:rhel-9-release-golang-1.24-openshift-4.20 /bin/bash -c "cd /data && make cross"
 sudo mv out/linux-amd64/crc /usr/local/bin/
 popd
 

--- a/systemd/crc-cluster-status.sh
+++ b/systemd/crc-cluster-status.sh
@@ -6,7 +6,7 @@ export KUBECONFIG=/opt/kubeconfig
 
 rm -rf /tmp/.crc-cluster-ready
 
-if ! oc adm wait-for-stable-cluster --minimum-stable-period=3m --timeout=10m; then
+if ! oc adm wait-for-stable-cluster --minimum-stable-period=1m --timeout=10m; then
     exit 1
 fi
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Improvements
  - Faster cluster readiness by reducing the stability window from 3 minutes to 1 minute, potentially shortening startup times.

- Chores
  - Upgraded build images to newer platform versions (RHEL 9, Go 1.24, OpenShift 4.20) to align with current environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->