### PR TITLE
use chassis_asset_tag to detect if running on azure

### DIFF
--- a/systemd/crc-check-cloud-env.sh
+++ b/systemd/crc-check-cloud-env.sh
@@ -3,7 +3,7 @@
 if grep -qi 'ec2' /sys/class/dmi/id/product_uuid ||
    grep -qi 'google' /sys/class/dmi/id/product_name ||
    grep -qi 'openstack' /sys/class/dmi/id/product_name ||
-   grep -qi 'microsoft' /sys/class/dmi/id/sys_vendor; then
+   grep -qi '7783-7084-3265-9085-8269-3286-77' /sys/class/dmi/id/chassis_asset_tag; then
     exit 0
 else
     exit 1


### PR DESCRIPTION
earlier we were checking the file '/sys/class/dmi/id/sys_vendor' which contains the string 'Microsoft Corporation' in both cases of running on azure or locally on hyper-v which made the script to wrongly think it was running on a cloud environment

checking '/sys/class/dmi/id/chassis_asset_tag' for a specific string: '7783-7084-3265-9085-8269-3286-77' has better results as this is same for any linux machine deployed on azure

found this in: https://learn.microsoft.com/en-us/answers/questions/1417667/how-to-determine-a-linux-vm-is-an-azure-vm-using-a