### PR TITLE
Use CRC_REST_API_TOKEN as env instead CRC_HOSTS_API_TOKEN

### DIFF
--- a/routes-controller.yaml.in
+++ b/routes-controller.yaml.in
@@ -26,6 +26,7 @@ spec:
             secretKeyRef:
               name: crc-rest-api-token
               key: CRC_REST_API_TOKEN
+              optional: true
 ---
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy

--- a/routes-controller.yaml.in
+++ b/routes-controller.yaml.in
@@ -21,11 +21,11 @@ spec:
         name: routes-controller
         imagePullPolicy: IfNotPresent
         env:
-        - name: CRC_HOSTS_API_TOKEN
+        - name: CRC_REST_API_TOKEN
           valueFrom:
             secretKeyRef:
-              name: crc-hosts-api-token
-              key: CRC_HOSTS_API_TOKEN
+              name: crc-rest-api-token
+              key: CRC_REST_API_TOKEN
 ---
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for optionally configuring the REST API token through deployment settings.

* **Bug Fixes**
  * Removed the requirement for the previous hosts API token configuration, simplifying deployment setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->